### PR TITLE
chore: bump ape to 0.3, fix errors + install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,17 @@ Install requirements.
 
 `python3 -m pip install -r requirements-dev.txt`
 
+Install plugins with:
+
+`ape plugins install .`
+
 Compile smart contracts with:
 
 `ape compile`
 
 and test smart contracts with:
 
-`ape test`
+`ape test -s`
 
 See the ApeWorx [documentation](https://docs.apeworx.io/ape/stable/) and [github](https://github.com/ApeWorX/ape) for more information.
 

--- a/contracts/test/Token.sol
+++ b/contracts/test/Token.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.13;
+pragma solidity 0.8.14;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,2 @@
 black==22.3.0
-eth-ape>=0.2.8
-ape-hardhat>=0.2.2
-ape-solidity>=0.2.3
-ape-vyper>=0.1.0b6
+eth-ape>=0.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def fish_amount():
 @pytest.fixture(scope="session")
 def fish(accounts, asset, gov, fish_amount):
     fish = accounts[1]
-    asset.mint(fish, fish_amount, sender=gov)
+    asset.mint(fish.address, fish_amount, sender=gov)
     yield fish
 
 
@@ -28,7 +28,7 @@ def shark_amount():
 @pytest.fixture(scope="session")
 def shark(accounts, asset, gov, shark_amount):
     shark = accounts[2]
-    asset.mint(shark, shark_amount, sender=gov)
+    asset.mint(shark.address, shark_amount, sender=gov)
     yield shark
 
 
@@ -40,7 +40,7 @@ def whale_amount():
 @pytest.fixture(scope="session")
 def whale(accounts):
     whale = accounts[3]
-    asset.mint(whale, whale_amount, sender=gov)
+    asset.mint(whale.address, whale_amount, sender=gov)
     yield whale
 
 

--- a/tests/e2e/test_deposit_withdraw_flow.py
+++ b/tests/e2e/test_deposit_withdraw_flow.py
@@ -6,8 +6,8 @@ def test_deposit_and_withdraw(asset, fish, create_vault):
     vault = create_vault(asset)
     balance = asset.balanceOf(fish)
     half_balance = balance // 2
-    asset.approve(vault, balance, sender=fish)
-    vault.deposit(half_balance, fish, sender=fish)
+    asset.approve(vault.address, balance, sender=fish)
+    vault.deposit(half_balance, fish.address, sender=fish)
 
     assert vault.totalSupply() == half_balance
     assert asset.balanceOf(vault) == half_balance
@@ -17,7 +17,7 @@ def test_deposit_and_withdraw(asset, fish, create_vault):
     assert vault.pricePerShare(sender=fish) == 10 ** asset.decimals()  # 1:1 price
 
     # deposit again to test behavior when vault has existing shares
-    vault.deposit(MAX_INT, fish, sender=fish)
+    vault.deposit(MAX_INT, fish.address, sender=fish)
 
     assert vault.totalSupply() == balance
     assert asset.balanceOf(vault) == balance
@@ -26,7 +26,7 @@ def test_deposit_and_withdraw(asset, fish, create_vault):
     assert vault.pricePerShare(sender=fish) == 10 ** asset.decimals()  # 1:1 price
 
     strategies = []
-    vault.withdraw(half_balance, fish, strategies, sender=fish)
+    vault.withdraw(half_balance, fish.address, strategies, sender=fish)
 
     assert vault.totalSupply() == half_balance
     assert asset.balanceOf(vault) == half_balance
@@ -34,7 +34,7 @@ def test_deposit_and_withdraw(asset, fish, create_vault):
     assert vault.totalDebt() == 0
     assert vault.pricePerShare(sender=fish) == 10 ** asset.decimals()  # 1:1 price
 
-    vault.withdraw(half_balance, fish, strategies, sender=fish)
+    vault.withdraw(half_balance, fish.address, strategies, sender=fish)
 
     checks.check_vault_empty(vault)
     assert asset.balanceOf(vault) == 0
@@ -52,8 +52,8 @@ def test_delegated_deposit_and_withdraw(
     assert balance > 0
 
     # 1. Deposit from fish and send shares to bunny
-    asset.approve(vault, asset.balanceOf(fish), sender=fish)
-    vault.deposit(asset.balanceOf(fish), bunny, sender=fish)
+    asset.approve(vault.address, asset.balanceOf(fish), sender=fish)
+    vault.deposit(asset.balanceOf(fish), bunny.address, sender=fish)
 
     # fish no longer has any assets
     assert asset.balanceOf(fish) == 0
@@ -63,7 +63,7 @@ def test_delegated_deposit_and_withdraw(
     assert vault.balanceOf(bunny) == balance
 
     # 2. Withdraw from bunny to doggie
-    vault.withdraw(vault.balanceOf(bunny), doggie, strategies, sender=bunny)
+    vault.withdraw(vault.balanceOf(bunny), doggie.address, strategies, sender=bunny)
 
     # bunny no longer has any shares
     assert vault.balanceOf(bunny) == 0
@@ -73,8 +73,8 @@ def test_delegated_deposit_and_withdraw(
     assert asset.balanceOf(doggie) == balance
 
     # 3. Deposit from doggie and send shares to panda
-    asset.approve(vault, asset.balanceOf(doggie), sender=doggie)
-    vault.deposit(asset.balanceOf(doggie), panda, sender=doggie)
+    asset.approve(vault.address, asset.balanceOf(doggie), sender=doggie)
+    vault.deposit(asset.balanceOf(doggie), panda.address, sender=doggie)
 
     # doggie no longer has any assets
     assert asset.balanceOf(doggie) == 0
@@ -84,7 +84,7 @@ def test_delegated_deposit_and_withdraw(
     assert vault.balanceOf(panda) == balance
 
     # 4. Withdraw from panda to woofy
-    vault.withdraw(vault.balanceOf(panda), woofy, strategies, sender=panda)
+    vault.withdraw(vault.balanceOf(panda), woofy.address, strategies, sender=panda)
 
     # panda no longer has any shares
     assert vault.balanceOf(panda) == 0

--- a/tests/unit/vault/test_shares.py
+++ b/tests/unit/vault/test_shares.py
@@ -8,7 +8,7 @@ def test_deposit_with_invalid_recipient(fish, asset, create_vault):
     amount = 0
 
     with ape.reverts("invalid recipient"):
-        vault.deposit(amount, vault, sender=fish)
+        vault.deposit(amount, vault.address, sender=fish)
     with ape.reverts("invalid recipient"):
         vault.deposit(amount, ZERO_ADDRESS, sender=fish)
 
@@ -18,7 +18,7 @@ def test_deposit_with_zero_funds(fish, asset, create_vault):
     amount = 0
 
     with ape.reverts("cannot deposit zero"):
-        vault.deposit(amount, fish, sender=fish)
+        vault.deposit(amount, fish.address, sender=fish)
 
 
 def test_deposit(fish, asset, create_vault):
@@ -47,8 +47,8 @@ def test_deposit_all(fish, asset, create_vault):
     amount = balance
     shares = balance
 
-    asset.approve(vault, balance, sender=fish)
-    tx = vault.deposit(MAX_INT, fish, sender=fish)
+    asset.approve(vault.address, balance, sender=fish)
+    tx = vault.deposit(MAX_INT, fish.address, sender=fish)
     event = list(tx.decode_logs(vault.Deposit))
 
     assert len(event) == 1
@@ -71,7 +71,7 @@ def test_withdraw(fish, asset, create_vault):
     balance = asset.balanceOf(fish)
     actions.user_deposit(fish, vault, asset, amount)
 
-    tx = vault.withdraw(shares, fish, strategies, sender=fish)
+    tx = vault.withdraw(shares, fish.address, strategies, sender=fish)
     event = list(tx.decode_logs(vault.Withdraw))
 
     assert len(event) == 1
@@ -93,7 +93,7 @@ def test_withdraw_with_insufficient_shares(fish, asset, create_vault):
     actions.user_deposit(fish, vault, asset, amount)
 
     with ape.reverts("insufficient shares to withdraw"):
-        vault.withdraw(shares, fish, strategies, sender=fish)
+        vault.withdraw(shares, fish.address, strategies, sender=fish)
 
 
 def test_withdraw_with_no_shares(fish, asset, create_vault):
@@ -102,7 +102,7 @@ def test_withdraw_with_no_shares(fish, asset, create_vault):
     strategies = []
 
     with ape.reverts("no shares to withdraw"):
-        vault.withdraw(shares, fish, strategies, sender=fish)
+        vault.withdraw(shares, fish.address, strategies, sender=fish)
 
 
 def test_withdraw_all(fish, asset, create_vault):
@@ -114,7 +114,7 @@ def test_withdraw_all(fish, asset, create_vault):
 
     actions.user_deposit(fish, vault, asset, amount)
 
-    tx = vault.withdraw(MAX_INT, fish, strategies, sender=fish)
+    tx = vault.withdraw(MAX_INT, fish.address, strategies, sender=fish)
     event = list(tx.decode_logs(vault.Withdraw))
 
     assert len(event) == 1
@@ -137,8 +137,8 @@ def test_delegated_deposit(fish, bunny, asset, create_vault):
     assert balance > 0
 
     # delegate deposit to bunny
-    asset.approve(vault, amount, sender=fish)
-    tx = vault.deposit(amount, bunny, sender=fish)
+    asset.approve(vault.address, amount, sender=fish)
+    tx = vault.deposit(amount, bunny.address, sender=fish)
     event = list(tx.decode_logs(vault.Deposit))
 
     assert len(event) == 1
@@ -168,7 +168,7 @@ def test_delegated_withdrawal(fish, bunny, asset, create_vault):
     actions.user_deposit(fish, vault, asset, amount)
 
     # withdraw to bunny
-    tx = vault.withdraw(vault.balanceOf(fish), bunny, strategies, sender=fish)
+    tx = vault.withdraw(vault.balanceOf(fish), bunny.address, strategies, sender=fish)
     event = list(tx.decode_logs(vault.Withdraw))
 
     assert len(event) == 1

--- a/tests/utils/actions.py
+++ b/tests/utils/actions.py
@@ -4,7 +4,7 @@ from utils.constants import MAX_INT
 
 def user_deposit(user, vault, token, amount) -> ContractLog:
     if token.allowance(user, vault) < amount:
-        token.approve(vault, MAX_INT, sender=user)
-    tx = vault.deposit(amount, user, sender=user)
+        token.approve(vault.address, MAX_INT, sender=user)
+    tx = vault.deposit(amount, user.address, sender=user)
     assert token.balanceOf(vault) == amount
     return tx


### PR DESCRIPTION
## Description

- bumped ape to 0.3
- fixed test errors (0.3 checks types more rigorously in function calls)
- fixed install instructions to use `ape install plugins .`

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
