### PR TITLE
feat: implement withdraw from strategies

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def whale_amount():
 
 
 @pytest.fixture(scope="session")
-def whale(accounts):
+def whale(accounts, asset, gov, whale_amount):
     whale = accounts[2]
     asset.mint(whale.address, whale_amount, sender=gov)
     yield whale

--- a/tests/e2e/test_strategy_withdraw_flow.py
+++ b/tests/e2e/test_strategy_withdraw_flow.py
@@ -1,7 +1,7 @@
 import ape
 from ape import chain
 from utils import actions, checks
-from utils.constants import DAY, MAX_INT
+from utils.constants import DAY
 
 
 def test_multiple_strategy_withdraw_flow(
@@ -32,18 +32,10 @@ def test_multiple_strategy_withdraw_flow(
 
     # set up strategies
     for strategy in strategies:
-        vault.addStrategy(strategy.address, sender=gov)
-        strategy.setMinDebt(0, sender=gov)
-        strategy.setMaxDebt(MAX_INT, sender=gov)
+        actions.add_strategy_to_vault(gov, strategy, vault)
 
-    vault.updateMaxDebtForStrategy(
-        liquid_strategy.address, liquid_strategy_debt, sender=gov
-    )
-    vault.updateDebt(liquid_strategy.address, sender=gov)
-    vault.updateMaxDebtForStrategy(
-        locked_strategy.address, locked_strategy_debt, sender=gov
-    )
-    vault.updateDebt(locked_strategy.address, sender=gov)
+    actions.add_debt_to_strategy(gov, liquid_strategy, vault, liquid_strategy_debt)
+    actions.add_debt_to_strategy(gov, locked_strategy, vault, locked_strategy_debt)
 
     # lock half of assets in locked strategy
     locked_strategy.setLockedFunds(amount_to_lock, DAY, sender=gov)

--- a/tests/e2e/test_strategy_withdraw_flow.py
+++ b/tests/e2e/test_strategy_withdraw_flow.py
@@ -1,0 +1,125 @@
+import ape
+from ape import chain
+from utils import actions, checks
+from utils.constants import DAY, MAX_INT
+
+
+def test_multiple_strategy_withdraw_flow(
+    chain,
+    gov,
+    fish,
+    whale,
+    fish_amount,
+    whale_amount,
+    bunny,
+    asset,
+    create_vault,
+    create_strategy,
+    create_locked_strategy,
+):
+    vault = create_vault(asset)
+    vault_balance = fish_amount + whale_amount
+    liquid_strategy_debt = vault_balance // 4  # deposit a quarter
+    locked_strategy_debt = vault_balance // 2  # deposit half, locking half of deposit
+    amount_to_lock = locked_strategy_debt // 2
+    liquid_strategy = create_strategy(vault)
+    locked_strategy = create_locked_strategy(vault)
+    strategies = [locked_strategy, liquid_strategy]
+
+    # deposit assets to vault
+    actions.user_deposit(fish, vault, asset, fish_amount)
+    actions.user_deposit(whale, vault, asset, whale_amount)
+
+    # set up strategies
+    for strategy in strategies:
+        vault.addStrategy(strategy.address, sender=gov)
+        strategy.setMinDebt(0, sender=gov)
+        strategy.setMaxDebt(MAX_INT, sender=gov)
+
+    vault.updateMaxDebtForStrategy(
+        liquid_strategy.address, liquid_strategy_debt, sender=gov
+    )
+    vault.updateDebt(liquid_strategy.address, sender=gov)
+    vault.updateMaxDebtForStrategy(
+        locked_strategy.address, locked_strategy_debt, sender=gov
+    )
+    vault.updateDebt(locked_strategy.address, sender=gov)
+
+    # lock half of assets in locked strategy
+    locked_strategy.setLockedFunds(amount_to_lock, DAY, sender=gov)
+
+    current_idle = vault_balance // 4
+    current_debt = vault_balance * 3 // 4
+
+    assert vault.totalIdle() == current_idle
+    assert vault.totalDebt() == current_debt
+    assert asset.balanceOf(vault) == current_idle
+    assert asset.balanceOf(liquid_strategy) == liquid_strategy_debt
+    assert asset.balanceOf(locked_strategy) == locked_strategy_debt
+
+    # withdraw small amount as fish from total idle
+    vault.withdraw(fish_amount // 2, fish.address, strategies, sender=fish)
+
+    current_idle -= fish_amount // 2
+
+    assert asset.balanceOf(fish) == fish_amount // 2
+    assert vault.totalIdle() == current_idle
+    assert vault.totalDebt() == current_debt
+    assert asset.balanceOf(vault) == current_idle
+    assert asset.balanceOf(liquid_strategy) == liquid_strategy_debt
+    assert asset.balanceOf(locked_strategy) == locked_strategy_debt
+
+    # drain remaining total idle as whale
+    vault.withdraw(current_idle, whale.address, [], sender=whale)
+
+    assert asset.balanceOf(whale) == current_idle
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == current_debt
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(liquid_strategy) == liquid_strategy_debt
+    assert asset.balanceOf(locked_strategy) == locked_strategy_debt
+
+    # withdraw small amount as fish from locked_strategy to bunny
+    vault.withdraw(fish_amount // 2, bunny.address, [locked_strategy], sender=fish)
+
+    current_debt -= fish_amount // 2
+    locked_strategy_debt -= fish_amount // 2
+
+    assert asset.balanceOf(bunny) == fish_amount // 2
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == current_debt
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(liquid_strategy) == liquid_strategy_debt
+    assert asset.balanceOf(locked_strategy) == locked_strategy_debt
+
+    # attempt to withdraw remaining amount from only liquid strategy but revert
+    whale_balance = vault.balanceOf(whale) - amount_to_lock  # exclude locked amount
+    with ape.reverts("insufficient total idle"):
+        vault.withdraw(whale_balance, whale.address, [liquid_strategy], sender=whale)
+
+    # withdraw remaining balance
+    vault.withdraw(whale_balance, whale.address, strategies, sender=whale)
+
+    assert asset.balanceOf(whale) == (whale_amount - amount_to_lock)
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == amount_to_lock
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(liquid_strategy) == 0
+    assert asset.balanceOf(locked_strategy) == amount_to_lock
+
+    # unlock locked strategy assets
+    chain.pending_timestamp += DAY
+    locked_strategy.freeLockedFunds(sender=gov)
+
+    # withdraw newly unlocked funds
+    strategies = [
+        liquid_strategy,
+        locked_strategy,
+    ]  # test withdrawing from empty strategy
+    vault.withdraw(amount_to_lock, whale.address, strategies, sender=whale)
+
+    checks.check_vault_empty(vault)
+    assert asset.balanceOf(whale) == whale_amount
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(liquid_strategy) == 0
+    assert asset.balanceOf(locked_strategy) == 0

--- a/tests/e2e/test_strategy_withdraw_flow.py
+++ b/tests/e2e/test_strategy_withdraw_flow.py
@@ -1,7 +1,7 @@
 import ape
 from ape import chain
 from utils import actions, checks
-from utils.constants import DAY
+from utils.constants import DAY, ROLES
 
 
 def test_multiple_strategy_withdraw_flow(
@@ -31,6 +31,7 @@ def test_multiple_strategy_withdraw_flow(
     actions.user_deposit(whale, vault, asset, whale_amount)
 
     # set up strategies
+    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     for strategy in strategies:
         actions.add_strategy_to_vault(gov, strategy, vault)
 

--- a/tests/unit/vault/test_shares.py
+++ b/tests/unit/vault/test_shares.py
@@ -114,6 +114,12 @@ def test_withdraw_all(fish, asset, create_vault):
 
     actions.user_deposit(fish, vault, asset, amount)
 
+    print(vault.totalAssets())
+    print(vault.totalIdle())
+    print(vault.totalDebt())
+    print(asset.balanceOf(vault))
+    print(asset.balanceOf(fish))
+
     tx = vault.withdraw(MAX_INT, fish.address, strategies, sender=fish)
     event = list(tx.decode_logs(vault.Withdraw))
 
@@ -121,6 +127,12 @@ def test_withdraw_all(fish, asset, create_vault):
     assert event[0].recipient == fish
     assert event[0].shares == shares
     assert event[0].amount == amount
+
+    print(vault.totalAssets())
+    print(vault.totalIdle())
+    print(vault.totalDebt())
+    print(asset.balanceOf(vault))
+    print(asset.balanceOf(fish))
 
     checks.check_vault_empty(vault)
     assert asset.balanceOf(vault) == 0

--- a/tests/unit/vault/test_strategy_withdraw.py
+++ b/tests/unit/vault/test_strategy_withdraw.py
@@ -1,7 +1,7 @@
 import ape
 from ape import chain
 from utils import actions, checks
-from utils.constants import DAY, MAX_INT
+from utils.constants import DAY, ROLES
 
 
 def test_withdraw__with_inactive_strategy__reverts(
@@ -14,6 +14,7 @@ def test_withdraw__with_inactive_strategy__reverts(
     inactive_strategy = create_strategy(vault)
     strategies = [inactive_strategy]
 
+    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     actions.user_deposit(fish, vault, asset, amount)
     actions.add_strategy_to_vault(gov, strategy, vault)
     actions.add_debt_to_strategy(gov, strategy, vault, amount)
@@ -31,6 +32,7 @@ def test_withdraw__with_insufficient_funds_in_strategies__reverts(
     strategy = create_strategy(vault)
     strategies = []  # do not pass in any strategies
 
+    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     actions.user_deposit(fish, vault, asset, amount)
     actions.add_strategy_to_vault(gov, strategy, vault)
     actions.add_debt_to_strategy(gov, strategy, vault, amount)
@@ -48,6 +50,7 @@ def test_withdraw__with_liquid_strategy_only__withdraws(
     strategy = create_strategy(vault)
     strategies = [strategy]
 
+    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     actions.user_deposit(fish, vault, asset, amount)
     actions.add_strategy_to_vault(gov, strategy, vault)
     actions.add_debt_to_strategy(gov, strategy, vault, amount)
@@ -81,6 +84,7 @@ def test_withdraw__with_multiple_liquid_strategies__withdraws(
     actions.user_deposit(fish, vault, asset, amount)
 
     # set up strategies
+    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     for strategy in strategies:
         actions.add_strategy_to_vault(gov, strategy, vault)
         actions.add_debt_to_strategy(gov, strategy, vault, amount_per_strategy)
@@ -117,6 +121,7 @@ def test_withdraw__with_locked_and_liquid_strategy__withdraws(
     actions.user_deposit(fish, vault, asset, amount)
 
     # set up strategies
+    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     for strategy in strategies:
         actions.add_strategy_to_vault(gov, strategy, vault)
         actions.add_debt_to_strategy(gov, strategy, vault, amount_per_strategy)

--- a/tests/unit/vault/test_strategy_withdraw.py
+++ b/tests/unit/vault/test_strategy_withdraw.py
@@ -1,0 +1,180 @@
+import ape
+from ape import chain
+from utils import actions, checks
+from utils.constants import DAY, MAX_INT
+
+
+def test_withdraw__with_inactive_strategy__reverts(
+    gov, fish, fish_amount, asset, create_vault, create_strategy
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+    shares = amount
+    strategy = create_strategy(vault)
+    inactive_strategy = create_strategy(vault)
+    strategies = [inactive_strategy]
+
+    vault.addStrategy(strategy.address, sender=gov)
+    strategy.setMinDebt(0, sender=gov)
+    strategy.setMaxDebt(MAX_INT, sender=gov)
+    vault.updateMaxDebtForStrategy(strategy.address, MAX_INT, sender=gov)
+
+    # deposit assets to vault
+    actions.user_deposit(fish, vault, asset, amount)
+
+    # allocate all assets to strategy
+    vault.updateDebt(strategy.address, sender=gov)
+
+    with ape.reverts("inactive strategy"):
+        vault.withdraw(shares, fish.address, strategies, sender=fish)
+
+
+def test_withdraw__with_insufficient_funds_in_strategies__reverts(
+    gov, fish, fish_amount, asset, create_vault, create_strategy
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+    shares = amount
+    strategy = create_strategy(vault)
+    strategies = []  # do not pass in any strategies
+
+    vault.addStrategy(strategy.address, sender=gov)
+    strategy.setMinDebt(0, sender=gov)
+    strategy.setMaxDebt(MAX_INT, sender=gov)
+    vault.updateMaxDebtForStrategy(strategy.address, MAX_INT, sender=gov)
+
+    # deposit assets to vault
+    actions.user_deposit(fish, vault, asset, amount)
+
+    # allocate all assets to strategy
+    vault.updateDebt(strategy.address, sender=gov)
+
+    with ape.reverts("insufficient total idle"):
+        vault.withdraw(shares, fish.address, strategies, sender=fish)
+
+
+def test_withdraw__with_liquid_strategy_only__withdraws(
+    gov, fish, fish_amount, asset, create_vault, create_strategy
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+    shares = amount
+    strategy = create_strategy(vault)
+    strategies = [strategy]
+
+    vault.addStrategy(strategy.address, sender=gov)
+    strategy.setMinDebt(0, sender=gov)
+    strategy.setMaxDebt(MAX_INT, sender=gov)
+    vault.updateMaxDebtForStrategy(strategy.address, MAX_INT, sender=gov)
+
+    # deposit assets to vault
+    actions.user_deposit(fish, vault, asset, amount)
+
+    # allocate all assets to strategy
+    vault.updateDebt(strategy.address, sender=gov)
+
+    tx = vault.withdraw(shares, fish.address, strategies, sender=fish)
+    event = list(tx.decode_logs(vault.Withdraw))
+
+    assert len(event) == 1
+    assert event[0].recipient == fish
+    assert event[0].shares == shares
+    assert event[0].amount == amount
+
+    checks.check_vault_empty(vault)
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(strategy) == 0
+    assert asset.balanceOf(fish) == amount
+
+
+def test_withdraw__with_multiple_liquid_strategies__withdraws(
+    gov, fish, fish_amount, asset, create_vault, create_strategy
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+    amount_per_strategy = amount // 2  # deposit half of amount per strategy
+    shares = amount
+    first_strategy = create_strategy(vault)
+    second_strategy = create_strategy(vault)
+    strategies = [first_strategy, second_strategy]
+
+    # deposit assets to vault
+    actions.user_deposit(fish, vault, asset, amount)
+
+    # set up strategies
+    for strategy in strategies:
+        vault.addStrategy(strategy.address, sender=gov)
+        strategy.setMinDebt(0, sender=gov)
+        strategy.setMaxDebt(MAX_INT, sender=gov)
+        vault.updateMaxDebtForStrategy(
+            strategy.address, amount_per_strategy, sender=gov
+        )
+        # allocate assets to strategies
+        vault.updateDebt(strategy.address, sender=gov)
+
+    tx = vault.withdraw(shares, fish.address, strategies, sender=fish)
+    event = list(tx.decode_logs(vault.Withdraw))
+
+    assert len(event) == 1
+    assert event[0].recipient == fish
+    assert event[0].shares == shares
+    assert event[0].amount == amount
+
+    checks.check_vault_empty(vault)
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(first_strategy) == 0
+    assert asset.balanceOf(second_strategy) == 0
+    assert asset.balanceOf(fish) == amount
+
+
+def test_withdraw__with_locked_and_liquid_strategy__withdraws(
+    gov, fish, fish_amount, asset, create_vault, create_strategy, create_locked_strategy
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+    amount_per_strategy = amount // 2  # deposit half of amount per strategy
+    amount_to_lock = amount_per_strategy // 2  # lock only half of strategy
+    amount_to_withdraw = amount - amount_to_lock
+    shares = amount - amount_to_lock
+    liquid_strategy = create_strategy(vault)
+    locked_strategy = create_locked_strategy(vault)
+    strategies = [locked_strategy, liquid_strategy]
+
+    # deposit assets to vault
+    actions.user_deposit(fish, vault, asset, amount)
+
+    # set up strategies
+    for strategy in strategies:
+        vault.addStrategy(strategy.address, sender=gov)
+        strategy.setMinDebt(0, sender=gov)
+        strategy.setMaxDebt(MAX_INT, sender=gov)
+        vault.updateMaxDebtForStrategy(
+            strategy.address, amount_per_strategy, sender=gov
+        )
+        # allocate assets to strategies
+        vault.updateDebt(strategy.address, sender=gov)
+
+    # lock half of assets in locked strategy
+    locked_strategy.setLockedFunds(amount_to_lock, DAY, sender=gov)
+
+    tx = vault.withdraw(shares, fish.address, strategies, sender=fish)
+    event = list(tx.decode_logs(vault.Withdraw))
+
+    assert len(event) == 1
+    assert event[0].recipient == fish
+    assert event[0].shares == shares
+    assert event[0].amount == amount_to_withdraw
+
+    assert vault.totalAssets() == amount_to_lock
+    assert vault.totalSupply() == amount_to_lock
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == amount_to_lock
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(liquid_strategy) == 0
+    assert asset.balanceOf(locked_strategy) == amount_to_lock
+    assert asset.balanceOf(fish) == amount_to_withdraw
+
+
+def test_withdraw__with_lossy_and_liquid_strategy__withdraws():
+    # TODO: implement once withdrawing from lossy is accounted for
+    pass

--- a/tests/unit/vault/test_strategy_withdraw.py
+++ b/tests/unit/vault/test_strategy_withdraw.py
@@ -14,16 +14,9 @@ def test_withdraw__with_inactive_strategy__reverts(
     inactive_strategy = create_strategy(vault)
     strategies = [inactive_strategy]
 
-    vault.addStrategy(strategy.address, sender=gov)
-    strategy.setMinDebt(0, sender=gov)
-    strategy.setMaxDebt(MAX_INT, sender=gov)
-    vault.updateMaxDebtForStrategy(strategy.address, MAX_INT, sender=gov)
-
-    # deposit assets to vault
     actions.user_deposit(fish, vault, asset, amount)
-
-    # allocate all assets to strategy
-    vault.updateDebt(strategy.address, sender=gov)
+    actions.add_strategy_to_vault(gov, strategy, vault)
+    actions.add_debt_to_strategy(gov, strategy, vault, amount)
 
     with ape.reverts("inactive strategy"):
         vault.withdraw(shares, fish.address, strategies, sender=fish)
@@ -38,16 +31,9 @@ def test_withdraw__with_insufficient_funds_in_strategies__reverts(
     strategy = create_strategy(vault)
     strategies = []  # do not pass in any strategies
 
-    vault.addStrategy(strategy.address, sender=gov)
-    strategy.setMinDebt(0, sender=gov)
-    strategy.setMaxDebt(MAX_INT, sender=gov)
-    vault.updateMaxDebtForStrategy(strategy.address, MAX_INT, sender=gov)
-
-    # deposit assets to vault
     actions.user_deposit(fish, vault, asset, amount)
-
-    # allocate all assets to strategy
-    vault.updateDebt(strategy.address, sender=gov)
+    actions.add_strategy_to_vault(gov, strategy, vault)
+    actions.add_debt_to_strategy(gov, strategy, vault, amount)
 
     with ape.reverts("insufficient total idle"):
         vault.withdraw(shares, fish.address, strategies, sender=fish)
@@ -62,16 +48,9 @@ def test_withdraw__with_liquid_strategy_only__withdraws(
     strategy = create_strategy(vault)
     strategies = [strategy]
 
-    vault.addStrategy(strategy.address, sender=gov)
-    strategy.setMinDebt(0, sender=gov)
-    strategy.setMaxDebt(MAX_INT, sender=gov)
-    vault.updateMaxDebtForStrategy(strategy.address, MAX_INT, sender=gov)
-
-    # deposit assets to vault
     actions.user_deposit(fish, vault, asset, amount)
-
-    # allocate all assets to strategy
-    vault.updateDebt(strategy.address, sender=gov)
+    actions.add_strategy_to_vault(gov, strategy, vault)
+    actions.add_debt_to_strategy(gov, strategy, vault, amount)
 
     tx = vault.withdraw(shares, fish.address, strategies, sender=fish)
     event = list(tx.decode_logs(vault.Withdraw))
@@ -103,14 +82,8 @@ def test_withdraw__with_multiple_liquid_strategies__withdraws(
 
     # set up strategies
     for strategy in strategies:
-        vault.addStrategy(strategy.address, sender=gov)
-        strategy.setMinDebt(0, sender=gov)
-        strategy.setMaxDebt(MAX_INT, sender=gov)
-        vault.updateMaxDebtForStrategy(
-            strategy.address, amount_per_strategy, sender=gov
-        )
-        # allocate assets to strategies
-        vault.updateDebt(strategy.address, sender=gov)
+        actions.add_strategy_to_vault(gov, strategy, vault)
+        actions.add_debt_to_strategy(gov, strategy, vault, amount_per_strategy)
 
     tx = vault.withdraw(shares, fish.address, strategies, sender=fish)
     event = list(tx.decode_logs(vault.Withdraw))
@@ -145,14 +118,8 @@ def test_withdraw__with_locked_and_liquid_strategy__withdraws(
 
     # set up strategies
     for strategy in strategies:
-        vault.addStrategy(strategy.address, sender=gov)
-        strategy.setMinDebt(0, sender=gov)
-        strategy.setMaxDebt(MAX_INT, sender=gov)
-        vault.updateMaxDebtForStrategy(
-            strategy.address, amount_per_strategy, sender=gov
-        )
-        # allocate assets to strategies
-        vault.updateDebt(strategy.address, sender=gov)
+        actions.add_strategy_to_vault(gov, strategy, vault)
+        actions.add_debt_to_strategy(gov, strategy, vault, amount_per_strategy)
 
     # lock half of assets in locked strategy
     locked_strategy.setLockedFunds(amount_to_lock, DAY, sender=gov)

--- a/tests/utils/actions.py
+++ b/tests/utils/actions.py
@@ -15,6 +15,14 @@ def airdrop_asset(gov, asset, target, amount):
     asset.mint(target.address, amount, sender=gov)
 
 
+# used for new adding a new strategy to vault with unlimited max debt settings
+def add_strategy_to_vault(user, strategy, vault):
+    vault.addStrategy(strategy.address, sender=user)
+    strategy.setMinDebt(0, sender=user)
+    strategy.setMaxDebt(MAX_INT, sender=user)
+
+
+# used to add debt to a strategy
 def add_debt_to_strategy(user, strategy, vault, max_debt: int):
     vault.updateMaxDebtForStrategy(strategy.address, max_debt, sender=user)
     vault.updateDebt(strategy.address, sender=user)

--- a/tests/utils/actions.py
+++ b/tests/utils/actions.py
@@ -3,10 +3,11 @@ from utils.constants import MAX_INT
 
 
 def user_deposit(user, vault, token, amount) -> ContractLog:
+    initial_balance = token.balanceOf(vault)
     if token.allowance(user, vault) < amount:
         token.approve(vault.address, MAX_INT, sender=user)
     tx = vault.deposit(amount, user.address, sender=user)
-    assert token.balanceOf(vault) == amount
+    assert token.balanceOf(vault) == initial_balance + amount
     return tx
 
 


### PR DESCRIPTION
## Description

Implement the ability to withdraw from strategies. Withdrawing from lossy strategies not handled yet (as it requires the losses to be reported).
Added e2e test for withdrawing from strategies. 

Close #33 

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
