### PR TITLE
feat: minimumTotalIdle

### DIFF
--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -77,6 +77,9 @@ event UpdatedMaxDebtForStrategy:
 event UpdateDepositLimit:
     depositLimit: uint256
 
+event UpdateMinimumTotalIdle:
+    minimumTotalIdle: uint256
+
 # STRUCTS #
 struct StrategyParams:
     activation: uint256
@@ -109,6 +112,7 @@ allowance: public(HashMap[address, HashMap[address, uint256]])
 totalSupply: public(uint256)
 totalDebt: public(uint256)
 totalIdle: public(uint256)
+minimumTotalIdle: public(uint256)
 roles: public(HashMap[address, Roles])
 lastReport: public(uint256)
 lockedProfit: public(uint256)
@@ -678,6 +682,16 @@ def updateDebt(strategy: address) -> uint256:
     if currentDebt > newDebt:
         # reduce debt
         assetsToWithdraw: uint256 = currentDebt - newDebt
+
+        # ensure we always have minimumTotalIdle when updating debt
+        # HACK: to save gas
+        minimumTotalIdle: uint256 = self.minimumTotalIdle
+        totalIdle: uint256 = self.totalIdle
+
+        if totalIdle + assetsToWithdraw < minimumTotalIdle:
+            assetsToWithdraw = minimumTotalIdle-totalIdle   
+            newDebt = currentDebt-assetsToWithdraw
+
         withdrawable: uint256 = IStrategy(strategy).withdrawable()
         assert withdrawable != 0, "nothing to withdraw"
 
@@ -694,9 +708,17 @@ def updateDebt(strategy: address) -> uint256:
     else:
         # increase debt
         assetsToTransfer: uint256 = newDebt - currentDebt
+        # take into consideration minimumTotalIdle
+        # HACK: to save gas
+        minimumTotalIdle: uint256 = self.minimumTotalIdle
+        totalIdle: uint256 = self.totalIdle
+
+        assert totalIdle > minimumTotalIdle, "no funds to deposit"
+        availableIdle :uint256 = totalIdle - minimumTotalIdle
+
         # if insufficient funds to deposit, transfer only what is free
-        if assetsToTransfer > self.totalIdle:
-            assetsToTransfer = self.totalIdle
+        if assetsToTransfer > availableIdle:
+            assetsToTransfer = availableIdle
             newDebt = currentDebt + assetsToTransfer
         if assetsToTransfer > 0:
             ASSET.transfer(strategy, assetsToTransfer)
@@ -783,6 +805,12 @@ def setDepositLimit(depositLimit: uint256):
     # TODO: permissioning: CONFIG_MANAGER
     self.depositLimit = depositLimit
     log UpdateDepositLimit(depositLimit)
+
+@external 
+def setMinimumTotalIdle(minimumTotalIdle: uint256):
+    self._enforce_role(msg.sender, Roles.DEBT_MANAGER)
+    self.minimumTotalIdle = minimumTotalIdle
+    log UpdateMinimumTotalIdle(minimumTotalIdle)
 
 
 # def forceProcessReport(strategy: address):

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -689,8 +689,8 @@ def updateDebt(strategy: address) -> uint256:
         totalIdle: uint256 = self.totalIdle
 
         if totalIdle + assetsToWithdraw < minimumTotalIdle:
-            assetsToWithdraw = minimumTotalIdle-totalIdle   
-            newDebt = currentDebt-assetsToWithdraw
+            assetsToWithdraw = minimumTotalIdle - totalIdle   
+            newDebt = currentDebt - assetsToWithdraw
 
         withdrawable: uint256 = IStrategy(strategy).withdrawable()
         assert withdrawable != 0, "nothing to withdraw"
@@ -714,7 +714,7 @@ def updateDebt(strategy: address) -> uint256:
         totalIdle: uint256 = self.totalIdle
 
         assert totalIdle > minimumTotalIdle, "no funds to deposit"
-        availableIdle :uint256 = totalIdle - minimumTotalIdle
+        availableIdle: uint256 = totalIdle - minimumTotalIdle
 
         # if insufficient funds to deposit, transfer only what is free
         if assetsToTransfer > availableIdle:

--- a/tests/unit/vault/test_debt_management.py
+++ b/tests/unit/vault/test_debt_management.py
@@ -193,3 +193,204 @@ def test_update_debt__with_new_debt_less_than_min_desired_debt__reverts(
 
     with ape.reverts("new debt less than min debt"):
         vault.updateDebt(strategy.address, sender=gov)
+
+
+
+
+@pytest.mark.parametrize("minimum_total_idle", [0, 10**21])
+def test_set_minimum_total_idle__with_minimum_total_idle(gov, vault, minimum_total_idle):
+
+    tx = vault.setMinimumTotalIdle(minimum_total_idle, sender=gov)
+    assert vault.minimumTotalIdle() == minimum_total_idle
+
+    event = list(tx.decode_logs(vault.UpdateMinimumTotalIdle))
+    assert len(event) == 1
+    assert event[0].minimumTotalIdle == minimum_total_idle
+
+
+@pytest.mark.parametrize("minimum_total_idle", [10**21])
+def test_set_minimum_total_idle__without_permission__reverts(accounts, vault, minimum_total_idle):
+    """
+    Only DEBT_MANAGER should be able to update minimumTotalIdle. Reverting if found any other sender.
+    """
+    with ape.reverts():
+        vault.setMinimumTotalIdle(minimum_total_idle, sender=accounts[-1])
+
+
+def test_update_debt__with_current_debt_less_than_new_debt_and_minimum_total_idle(gov, asset, vault, strategy):
+    """
+    Current debt is greater than new debt. Vault has a minimum total idle value small that does not affect the updateDebt method.
+    """
+    vault_balance = asset.balanceOf(vault)
+    new_debt = vault_balance//2
+    current_debt = vault.strategies(strategy.address).currentDebt
+    difference = new_debt - current_debt
+    initial_idle = vault.totalIdle()
+    initial_debt = vault.totalDebt()
+
+    # set minimum total idle to a small value that doesn´t interfeer on updateDebt
+    minimum_total_idle = 1
+    vault.setMinimumTotalIdle(minimum_total_idle, sender=gov)
+    assert vault.minimumTotalIdle() == 1
+
+    # increase debt in strategy
+    vault.updateMaxDebtForStrategy(strategy.address, new_debt, sender=gov)
+
+    tx = vault.updateDebt(strategy.address, sender=gov)
+    event = list(tx.decode_logs(vault.DebtUpdated))
+
+    assert len(event) == 1
+    assert event[0].strategy == strategy.address
+    assert event[0].currentDebt == current_debt
+    assert event[0].newDebt == new_debt
+
+    assert vault.strategies(strategy.address).currentDebt == new_debt
+    assert asset.balanceOf(strategy) == new_debt
+    assert asset.balanceOf(vault) == (vault_balance - new_debt)
+    assert vault.totalIdle() == initial_idle - difference
+    assert vault.totalDebt() == initial_debt + difference
+
+    assert vault.totalIdle() > vault.minimumTotalIdle()
+
+
+def test_update_debt__with_current_debt_less_than_new_debt_and_total_idle_lower_than_minimum_total_idle__revert(gov, asset, vault, strategy):
+    """
+    Current debt is greater than new debt. Vault has a total idle value lower/equal to minimum total idle value. It cannot provide more 
+    assets to the strategy as there are no funds, we are therefore reverting.
+    """
+
+    vault_balance = asset.balanceOf(vault)
+    new_debt = vault_balance // 2
+
+    minimum_total_idle = vault.totalIdle()
+    vault.setMinimumTotalIdle(minimum_total_idle, sender=gov)
+    assert vault.minimumTotalIdle() == vault.totalIdle()
+
+    # increase debt in strategy
+    vault.updateMaxDebtForStrategy(strategy.address, new_debt, sender=gov)
+
+    with ape.reverts("no funds to deposit"):
+        vault.updateDebt(strategy.address, sender=gov)
+
+
+def test_update_debt__with_current_debt_less_than_new_debt_and_minimum_total_idle_reducing_new_debt(gov, asset, vault, strategy):
+    """
+    Current debt is lower than new debt. Value of minimum total idle reduces the amount of assets that the vault can provide.
+    """
+
+    vault_balance = asset.balanceOf(vault)
+    new_debt = vault_balance
+    current_debt = vault.strategies(strategy.address).currentDebt
+
+    initial_idle = vault.totalIdle()
+    initial_debt = vault.totalDebt()
+
+    # we ensure a small amount of liquidity remains in the vault
+    minimum_total_idle = vault_balance - 1
+    vault.setMinimumTotalIdle(minimum_total_idle, sender=gov)
+    assert vault.minimumTotalIdle() == vault_balance - 1
+
+    # vault can give as much as it reaches minimum_total_idle
+    expected_new_differnce = initial_idle - minimum_total_idle
+    expected_new_debt = current_debt + expected_new_differnce
+
+    # increase debt in strategy
+    vault.updateMaxDebtForStrategy(strategy.address, new_debt, sender=gov)
+
+    tx = vault.updateDebt(strategy.address, sender=gov)
+    event = list(tx.decode_logs(vault.DebtUpdated))
+
+    assert len(event) == 1
+    assert event[0].strategy == strategy.address
+    assert event[0].currentDebt == current_debt
+    assert event[0].newDebt == expected_new_debt
+
+    assert vault.strategies(strategy.address).currentDebt == expected_new_debt
+    assert asset.balanceOf(strategy) == expected_new_debt
+    assert asset.balanceOf(vault) == vault_balance - expected_new_differnce
+    assert vault.totalIdle() == initial_idle - expected_new_differnce
+    assert vault.totalDebt() == initial_debt + expected_new_differnce
+
+
+def test_update_debt__with_current_debt_greater_than_new_debt_and_minimum_total_idle(gov, asset, vault, strategy):
+    """
+    Current debt is greater than new debt. Vault has a minimum total idle value small that does not affect the updateDebt method.
+    """
+    vault_balance = asset.balanceOf(vault)
+    current_debt = vault_balance
+    new_debt = vault_balance // 2
+    difference = current_debt - new_debt
+
+    actions.add_debt_to_strategy(gov, strategy, vault, current_debt)
+
+    # we compute vault values again, as they have changed
+    vault_balance = asset.balanceOf(vault)
+    initial_idle = vault.totalIdle()
+    initial_debt = vault.totalDebt()
+
+    # small minimum total idle value not to interfeer with updateDebt method
+    minimum_total_idle = 1
+    vault.setMinimumTotalIdle(minimum_total_idle, sender=gov)
+
+    assert vault.minimumTotalIdle() == 1
+
+    # reduce debt in strategy
+    vault.updateMaxDebtForStrategy(strategy.address, new_debt, sender=gov)
+
+    tx = vault.updateDebt(strategy.address, sender=gov)
+    event = list(tx.decode_logs(vault.DebtUpdated))
+
+    assert len(event) == 1
+    assert event[0].strategy == strategy.address
+    assert event[0].currentDebt == current_debt
+    assert event[0].newDebt == new_debt
+
+    assert vault.strategies(strategy.address).currentDebt == new_debt
+    assert asset.balanceOf(strategy) == new_debt
+    assert asset.balanceOf(vault) == vault_balance + difference
+    assert vault.totalIdle() == initial_idle + difference
+    assert vault.totalDebt() == initial_debt - difference
+
+
+def test_update_debt__with_current_debt_greater_than_new_debt_and_total_iddle_less_than_minimum_total_idle(gov, asset, vault, strategy):
+    """
+    Current debt is greater than new debt. Vault has a total iddle value lower than its minimum total idle value.
+    .updateDebt will reduce the new debt value to increase the amount of assets that its getting from the strategy and ensure that
+    total idle value is greater than minimum total idle.
+    """
+    vault_balance = asset.balanceOf(vault)
+    current_debt = vault_balance
+    new_debt = vault_balance // 3
+
+    actions.add_debt_to_strategy(gov, strategy, vault, current_debt)
+
+    # we compute vault values again, as they have changed
+    vault_balance = asset.balanceOf(vault)
+    initial_idle = vault.totalIdle()
+    initial_debt = vault.totalDebt()
+
+    # we set minimum total idle to a value greater than debt difference
+    minimum_total_idle = current_debt - new_debt + 1
+    vault.setMinimumTotalIdle(minimum_total_idle, sender=gov)
+    assert vault.minimumTotalIdle() == current_debt - new_debt + 1
+
+    # we compute expected changes in debt due to minimum total idle need
+    expected_new_difference = minimum_total_idle-initial_idle
+    expected_new_debt = current_debt - expected_new_difference
+
+    # reduce debt in strategy
+    vault.updateMaxDebtForStrategy(strategy.address, new_debt, sender=gov)
+
+    tx = vault.updateDebt(strategy.address, sender=gov)
+    event = list(tx.decode_logs(vault.DebtUpdated))
+
+    assert len(event) == 1
+    assert event[0].strategy == strategy.address
+    assert event[0].currentDebt == current_debt
+    assert event[0].newDebt == expected_new_debt
+
+    assert vault.strategies(strategy.address).currentDebt == expected_new_debt
+    assert asset.balanceOf(strategy) == expected_new_debt
+    assert asset.balanceOf(vault) == vault_balance + expected_new_difference
+    assert vault.totalIdle() == initial_idle +  expected_new_difference
+    assert vault.totalDebt() == initial_debt -  expected_new_difference

--- a/tests/unit/vault/test_debt_management.py
+++ b/tests/unit/vault/test_debt_management.py
@@ -196,7 +196,9 @@ def test_update_debt__with_new_debt_less_than_min_desired_debt__reverts(
 
 
 @pytest.mark.parametrize("minimum_total_idle", [0, 10**21])
-def test_set_minimum_total_idle__with_minimum_total_idle(gov, vault, minimum_total_idle):
+def test_set_minimum_total_idle__with_minimum_total_idle(
+    gov, vault, minimum_total_idle
+):
 
     tx = vault.setMinimumTotalIdle(minimum_total_idle, sender=gov)
     assert vault.minimumTotalIdle() == minimum_total_idle
@@ -207,7 +209,9 @@ def test_set_minimum_total_idle__with_minimum_total_idle(gov, vault, minimum_tot
 
 
 @pytest.mark.parametrize("minimum_total_idle", [10**21])
-def test_set_minimum_total_idle__without_permission__reverts(accounts, vault, minimum_total_idle):
+def test_set_minimum_total_idle__without_permission__reverts(
+    accounts, vault, minimum_total_idle
+):
     """
     Only DEBT_MANAGER should be able to update minimumTotalIdle. Reverting if found any other sender.
     """
@@ -215,12 +219,14 @@ def test_set_minimum_total_idle__without_permission__reverts(accounts, vault, mi
         vault.setMinimumTotalIdle(minimum_total_idle, sender=accounts[-1])
 
 
-def test_update_debt__with_current_debt_less_than_new_debt_and_minimum_total_idle(gov, asset, vault, strategy):
+def test_update_debt__with_current_debt_less_than_new_debt_and_minimum_total_idle(
+    gov, asset, vault, strategy
+):
     """
     Current debt is greater than new debt. Vault has a minimum total idle value small that does not affect the updateDebt method.
     """
     vault_balance = asset.balanceOf(vault)
-    new_debt = vault_balance//2
+    new_debt = vault_balance // 2
     current_debt = vault.strategies(strategy.address).currentDebt
     difference = new_debt - current_debt
     initial_idle = vault.totalIdle()
@@ -251,9 +257,11 @@ def test_update_debt__with_current_debt_less_than_new_debt_and_minimum_total_idl
     assert vault.totalIdle() > vault.minimumTotalIdle()
 
 
-def test_update_debt__with_current_debt_less_than_new_debt_and_total_idle_lower_than_minimum_total_idle__revert(gov, asset, vault, strategy):
+def test_update_debt__with_current_debt_less_than_new_debt_and_total_idle_lower_than_minimum_total_idle__revert(
+    gov, asset, vault, strategy
+):
     """
-    Current debt is greater than new debt. Vault has a total idle value lower/equal to minimum total idle value. It cannot provide more 
+    Current debt is greater than new debt. Vault has a total idle value lower/equal to minimum total idle value. It cannot provide more
     assets to the strategy as there are no funds, we are therefore reverting.
     """
 
@@ -271,7 +279,9 @@ def test_update_debt__with_current_debt_less_than_new_debt_and_total_idle_lower_
         vault.updateDebt(strategy.address, sender=gov)
 
 
-def test_update_debt__with_current_debt_less_than_new_debt_and_minimum_total_idle_reducing_new_debt(gov, asset, vault, strategy):
+def test_update_debt__with_current_debt_less_than_new_debt_and_minimum_total_idle_reducing_new_debt(
+    gov, asset, vault, strategy
+):
     """
     Current debt is lower than new debt. Value of minimum total idle reduces the amount of assets that the vault can provide.
     """
@@ -310,7 +320,9 @@ def test_update_debt__with_current_debt_less_than_new_debt_and_minimum_total_idl
     assert vault.totalDebt() == initial_debt + expected_new_differnce
 
 
-def test_update_debt__with_current_debt_greater_than_new_debt_and_minimum_total_idle(gov, asset, vault, strategy):
+def test_update_debt__with_current_debt_greater_than_new_debt_and_minimum_total_idle(
+    gov, asset, vault, strategy
+):
     """
     Current debt is greater than new debt. Vault has a minimum total idle value small that does not affect the updateDebt method.
     """
@@ -350,7 +362,9 @@ def test_update_debt__with_current_debt_greater_than_new_debt_and_minimum_total_
     assert vault.totalDebt() == initial_debt - difference
 
 
-def test_update_debt__with_current_debt_greater_than_new_debt_and_total_iddle_less_than_minimum_total_idle(gov, asset, vault, strategy):
+def test_update_debt__with_current_debt_greater_than_new_debt_and_total_iddle_less_than_minimum_total_idle(
+    gov, asset, vault, strategy
+):
     """
     Current debt is greater than new debt. Vault has a total iddle value lower than its minimum total idle value.
     .updateDebt will reduce the new debt value to increase the amount of assets that its getting from the strategy and ensure that
@@ -373,7 +387,7 @@ def test_update_debt__with_current_debt_greater_than_new_debt_and_total_iddle_le
     assert vault.minimumTotalIdle() == current_debt - new_debt + 1
 
     # we compute expected changes in debt due to minimum total idle need
-    expected_new_difference = minimum_total_idle-initial_idle
+    expected_new_difference = minimum_total_idle - initial_idle
     expected_new_debt = current_debt - expected_new_difference
 
     # reduce debt in strategy
@@ -390,5 +404,5 @@ def test_update_debt__with_current_debt_greater_than_new_debt_and_total_iddle_le
     assert vault.strategies(strategy.address).currentDebt == expected_new_debt
     assert asset.balanceOf(strategy) == expected_new_debt
     assert asset.balanceOf(vault) == vault_balance + expected_new_difference
-    assert vault.totalIdle() == initial_idle +  expected_new_difference
-    assert vault.totalDebt() == initial_debt -  expected_new_difference
+    assert vault.totalIdle() == initial_idle + expected_new_difference
+    assert vault.totalDebt() == initial_debt - expected_new_difference

--- a/tests/unit/vault/test_debt_management.py
+++ b/tests/unit/vault/test_debt_management.py
@@ -362,11 +362,11 @@ def test_update_debt__with_current_debt_greater_than_new_debt_and_minimum_total_
     assert vault.totalDebt() == initial_debt - difference
 
 
-def test_update_debt__with_current_debt_greater_than_new_debt_and_total_iddle_less_than_minimum_total_idle(
+def test_update_debt__with_current_debt_greater_than_new_debt_and_total_idle_less_than_minimum_total_idle(
     gov, asset, vault, strategy
 ):
     """
-    Current debt is greater than new debt. Vault has a total iddle value lower than its minimum total idle value.
+    Current debt is greater than new debt. Vault has a total idle value lower than its minimum total idle value.
     .updateDebt will reduce the new debt value to increase the amount of assets that its getting from the strategy and ensure that
     total idle value is greater than minimum total idle.
     """

--- a/tests/unit/vault/test_debt_management.py
+++ b/tests/unit/vault/test_debt_management.py
@@ -195,8 +195,6 @@ def test_update_debt__with_new_debt_less_than_min_desired_debt__reverts(
         vault.updateDebt(strategy.address, sender=gov)
 
 
-
-
 @pytest.mark.parametrize("minimum_total_idle", [0, 10**21])
 def test_set_minimum_total_idle__with_minimum_total_idle(gov, vault, minimum_total_idle):
 


### PR DESCRIPTION
## Description

added variable `minimumTotalIdle` to ensure a minimum liquidity is always available in the Vault

Fixes #44 

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
