### PR TITLE
fix: ensured profits with fees are correctly considered

### DIFF
--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -612,7 +612,6 @@ def _process_report(strategy: address) -> (uint256, uint256):
         # if fee manager is not set, fees are zero
         if fee_manager != ZERO_ADDRESS:
             total_fees = IFeeManager(fee_manager).assess_fees(strategy, gain)
-            assert total_fees <= gain, "fees greater than gain"
             # if fees are non-zero, issue shares
             if total_fees > 0:
                 self._issue_shares_for_amount(total_fees, fee_manager)
@@ -626,19 +625,28 @@ def _process_report(strategy: address) -> (uint256, uint256):
         if PROFIT_MAX_UNLOCK_TIME == 0:
             self.total_debt_ += gain + unlocked_profit
         else:
-            gain_without_fees: uint256 = gain - total_fees    
-            new_profit_locking_period: uint256 = 0           
-            if pending_profit != 0 or gain_without_fees != 0:
+            if total_fees < gain:
+                gain_without_fees: uint256 = gain - total_fees       
                 # The new locking period is the weighted average between the remaining time and the profit_max_unlock_time. 
                 # The weight used is the profit (pending_profit vs new_profit)
-                new_profit_locking_period = (pending_profit * remaining_time + gain_without_fees * PROFIT_MAX_UNLOCK_TIME) / (pending_profit + gain_without_fees)
+                new_profit_locking_period:uint256 = (pending_profit * remaining_time + gain_without_fees * PROFIT_MAX_UNLOCK_TIME) / (pending_profit + gain_without_fees)
                 self.profit_distribution_rate_ = (pending_profit + gain_without_fees) * MAX_BPS / new_profit_locking_period
                 self.profit_end_date =  block.timestamp + new_profit_locking_period
                 self.profit_last_update = block.timestamp
+                self.total_debt_ += unlocked_profit + total_fees
             else:
-                # To avoid division by 0
-                self.profit_distribution_rate_ = 0
-            self.total_debt_ += unlocked_profit + total_fees
+                if total_fees - gain < pending_profit :
+                    # If there is pending profit, we reduce it by the difference between total_fees and gain
+                    self.profit_distribution_rate_ = (pending_profit - (total_fees - gain)) * MAX_BPS / remaining_time
+                    self.profit_end_date =  block.timestamp + remaining_time
+                    self.profit_last_update = block.timestamp
+                    self.total_debt_ += unlocked_profit + total_fees
+                else:
+                    # If even pending profit is not enough. 
+                    # We don´t add whole total_fees to total_debt, as there is not enough, we only add what we can pay, else is repercuted on pps
+                    self.profit_distribution_rate_ = 0
+                    self.total_debt_ += unlocked_profit + gain + pending_profit
+
     
     self.strategies[strategy].last_report = block.timestamp
 

--- a/contracts/periphery/FlexibleFeeManager.vy
+++ b/contracts/periphery/FlexibleFeeManager.vy
@@ -1,0 +1,125 @@
+# @version 0.3.4
+
+# FeeManager without any fee threshold
+
+from vyper.interfaces import ERC20
+
+# INTERFACES #
+struct StrategyParams:
+    activation: uint256
+    last_report: uint256
+    current_debt: uint256
+    max_debt: uint256
+    total_gain: uint256
+    total_loss: uint256
+
+interface IVault:
+    def strategies(strategy: address) -> StrategyParams: view
+
+interface IStrategy:
+    def delegatedAssets() -> uint256: view
+
+# EVENTS #
+event CommitFeeManager:
+    fee_manager: address
+
+event ApplyFeeManager:
+    fee_manager: address
+
+event UpdatePerformanceFee:
+    performance_fee: uint256
+
+event UpdateManagementFee:
+    management_fee: uint256
+
+event DistributeRewards:
+    rewards: uint256
+
+
+# STRUCTS #
+struct Fee:
+    management_fee: uint256
+    performance_fee: uint256
+
+
+# CONSTANTS #
+MAX_BPS: constant(uint256) = 10_000
+# NOTE: A four-century period will be missing 3 of its 100 Julian leap years, leaving 97.
+#       So the average year has 365 + 97/400 = 365.2425 days
+#       ERROR(Julian): -0.0078
+#       ERROR(Gregorian): -0.0003
+#       A day = 24 * 60 * 60 sec = 86400 sec
+#       365.2425 * 86400 = 31556952.0
+SECS_PER_YEAR: constant(uint256) = 31_556_952  # 365.2425 days
+
+
+# STORAGE #
+fee_manager: public(address)
+future_fee_manager: public(address)
+fees: public(HashMap[address, Fee])
+
+
+@external
+def __init__():
+    self.fee_manager = msg.sender
+
+
+@view
+@external
+def assess_fees(strategy: address, gain: uint256) -> uint256:
+    """
+    @dev assumes gain > 0
+    """
+    strategy_params: StrategyParams = IVault(msg.sender).strategies(strategy)
+    fee: Fee = self.fees[strategy]
+    duration: uint256 = block.timestamp - strategy_params.last_report
+
+    management_fee: uint256 = (
+        ((strategy_params.current_debt - IStrategy(strategy).delegatedAssets()))
+        * duration
+        * fee.management_fee
+        / MAX_BPS
+        / SECS_PER_YEAR
+    )
+    performance_fee: uint256 = (gain * fee.performance_fee) / MAX_BPS
+    total_fee: uint256 = management_fee + performance_fee
+
+    return total_fee
+
+
+@external
+def distribute(vault: ERC20):
+    assert msg.sender == self.fee_manager, "not fee manager"
+    rewards: uint256 = vault.balanceOf(self)
+    vault.transfer(msg.sender, rewards)
+    log DistributeRewards(rewards)
+
+
+@external
+def set_performance_fee(vault: address, performance_fee: uint256):
+    assert msg.sender == self.fee_manager, "not fee manager"
+    self.fees[vault].performance_fee = performance_fee
+    log UpdatePerformanceFee(performance_fee)
+
+
+@external
+def set_management_fee(vault: address, management_fee: uint256):
+    assert msg.sender == self.fee_manager, "not fee manager"
+    self.fees[vault].management_fee = management_fee
+    log UpdateManagementFee(management_fee)
+
+
+@external
+def commit_fee_manager(future_fee_manager: address):
+    assert msg.sender == self.fee_manager, "not fee manager"
+    self.future_fee_manager = future_fee_manager
+    log CommitFeeManager(future_fee_manager)
+
+
+@external
+def apply_fee_manager():
+    assert msg.sender == self.fee_manager, "not fee manager"
+    assert self.future_fee_manager != ZERO_ADDRESS, "future fee manager != zero address"
+    future_fee_manager: address = self.future_fee_manager
+    self.fee_manager = future_fee_manager
+    log ApplyFeeManager(future_fee_manager)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from ape.types import ContractLog
 from eth_account.messages import encode_structured_data
 from utils.constants import MAX_INT, ROLES, WEEK
 
+
 # Accounts
 
 
@@ -103,9 +104,13 @@ def create_token(project, gov):
 
 
 @pytest.fixture(scope="session")
-def create_vault(project, gov, fee_manager):
+def create_vault(project, gov, fee_manager, flexible_fee_manager):
     def create_vault(
-        asset, governance=gov, deposit_limit=MAX_INT, max_profit_locking_time=WEEK
+        asset,
+        fee_manager=fee_manager,
+        governance=gov,
+        deposit_limit=MAX_INT,
+        max_profit_locking_time=WEEK,
     ):
         vault = gov.deploy(
             project.VaultV3, asset, "VaultV3", "AV", governance, max_profit_locking_time
@@ -191,6 +196,12 @@ def lossy_strategy(gov, vault, create_lossy_strategy):
 def fee_manager(project, gov):
     fee_manager = gov.deploy(project.FeeManager)
     yield fee_manager
+
+
+@pytest.fixture(scope="session")
+def flexible_fee_manager(project, gov):
+    flexible_fee_manager = gov.deploy(project.FlexibleFeeManager)
+    yield flexible_fee_manager
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/vault/test_strategy_profit_distribution.py
+++ b/tests/unit/vault/test_strategy_profit_distribution.py
@@ -453,7 +453,7 @@ def test_profit_distribution__one_gain_with_fees(
     add_debt_to_strategy(gov, strategy, vault, amount)
     # set up fee manager and fees
     management_fee = 0
-    performance_fee = 1000
+    performance_fee = 1_000
     set_fees_for_strategy(gov, strategy, fee_manager, management_fee, performance_fee)
 
     assert strategy.totalAssets() == amount
@@ -494,6 +494,241 @@ def test_profit_distribution__one_gain_with_fees(
     assert vault.profit_distribution_rate() / MAX_BPS == pytest.approx(
         profit_without_fees / WEEK, 1e-5
     )
+
+
+def test_profit_distribution__one_gain_with_100_percent_fees(
+    gov,
+    fish,
+    asset,
+    create_vault,
+    create_strategy,
+    user_deposit,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+    set_fees_for_strategy,
+    flexible_fee_manager,
+):
+    """
+    Scenario where there is a gain on day 1 of 1000 assets and there are performance fees of 100% of profit.
+    Initially we have 1000 assets and therefore 1000 shares (1:1).
+    """
+
+    amount = 10**9
+    profit = 10**9
+
+    # We reset time to 1 to facilitate reporting
+    chain.pending_timestamp = 1
+    chain.mine(timestamp=chain.pending_timestamp)
+
+    vault = create_vault(asset, fee_manager=flexible_fee_manager)
+    strategy = create_strategy(vault)
+
+    # deposit assets to vault and prepare strategy
+    user_deposit(fish, vault, asset, amount)
+    add_strategy_to_vault(gov, strategy, vault)
+    add_debt_to_strategy(gov, strategy, vault, amount)
+    # set up fee manager and fees
+    management_fee = 0
+    performance_fee = 10_000
+    set_fees_for_strategy(
+        gov, strategy, flexible_fee_manager, management_fee, performance_fee
+    )
+
+    assert strategy.totalAssets() == amount
+
+    assert vault.price_per_share() / 10 ** vault.decimals() == 1.0
+    pps_before_profit = vault.price_per_share()
+
+    # We create a virtual profit
+    asset.transfer(strategy, profit, sender=fish)
+
+    assert vault.totalAssets() == amount
+    assert vault.total_debt() == amount
+    assert vault.total_idle() == 0
+    assert vault.price_per_share() / 10 ** vault.decimals() == 1.0
+
+    assert vault.profit_distribution_rate() == 0
+
+    # We call process_report at t_1
+    chain.pending_timestamp = days_to_secs(1)
+    chain.mine(timestamp=chain.pending_timestamp)
+
+    tx = vault.process_report(strategy, sender=gov)
+
+    event = list(tx.decode_logs(vault.StrategyReported))
+    assert len(event) == 1
+    assert event[0].gain == profit
+
+    assert vault.totalAssets() == amount + profit
+    assert vault.total_debt() == amount + profit
+    assert vault.total_idle() == 0
+
+    assert vault.price_per_share() == pps_before_profit
+    assert vault.balanceOf(flexible_fee_manager) == vault.convertToShares(profit)
+    assert vault.profit_distribution_rate() == 0
+
+
+def test_profit_distribution__one_gain_with_200_percent_fees(
+    gov,
+    fish,
+    asset,
+    create_vault,
+    create_strategy,
+    user_deposit,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+    set_fees_for_strategy,
+    flexible_fee_manager,
+):
+    """
+    Scenario where there is a gain on day 1 of 1000 assets and there are performance fees of 200% of profit.
+    Initially we have 1000 assets and therefore 1000 shares (1:1).
+    """
+
+    amount = 10**9
+    profit = 10**9
+
+    # We reset time to 1 to facilitate reporting
+    chain.pending_timestamp = 1
+    chain.mine(timestamp=chain.pending_timestamp)
+
+    vault = create_vault(asset, fee_manager=flexible_fee_manager)
+    strategy = create_strategy(vault)
+
+    # deposit assets to vault and prepare strategy
+    user_deposit(fish, vault, asset, amount)
+    add_strategy_to_vault(gov, strategy, vault)
+    add_debt_to_strategy(gov, strategy, vault, amount)
+    # set up fee manager and fees
+    management_fee = 0
+    performance_fee = 20_000
+    set_fees_for_strategy(
+        gov, strategy, flexible_fee_manager, management_fee, performance_fee
+    )
+
+    assert strategy.totalAssets() == amount
+
+    assert vault.price_per_share() / 10 ** vault.decimals() == 1.0
+    pps_before_profit = vault.price_per_share()
+
+    # We create a virtual profit
+    asset.transfer(strategy, profit, sender=fish)
+
+    assert vault.totalAssets() == amount
+    assert vault.total_debt() == amount
+    assert vault.total_idle() == 0
+    assert vault.price_per_share() / 10 ** vault.decimals() == 1.0
+
+    assert vault.profit_distribution_rate() == 0
+
+    # We call process_report at t_1
+    chain.pending_timestamp = days_to_secs(1)
+    chain.mine(timestamp=chain.pending_timestamp)
+
+    tx = vault.process_report(strategy, sender=gov)
+
+    event = list(tx.decode_logs(vault.StrategyReported))
+    assert len(event) == 1
+    assert event[0].gain == profit
+
+    assert vault.totalAssets() == amount + profit
+    assert vault.total_debt() == amount + profit
+    assert vault.total_idle() == 0
+
+    # Due to the fact that we were unable to pay fees with profit, pps its lowered
+    assert vault.price_per_share() < pps_before_profit
+    # Fee Managers gets shares at 1:1 price
+    assert vault.balanceOf(flexible_fee_manager) == int(2 * profit)
+    assert vault.profit_distribution_rate() == 0
+
+
+def test_profit_distribution__one_gain_with_200_percent_fees_and_enough_pending_profit(
+    gov,
+    fish,
+    asset,
+    create_vault,
+    create_strategy,
+    user_deposit,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+    set_fees_for_strategy,
+    flexible_fee_manager,
+):
+    """
+    Scenario where there is a gain on day 1 of 1000 assets without fees. After there is another profit
+    and there are performance fees of 200% of profit.
+    Initially we have 1000 assets and therefore 1000 shares (1:1).
+    """
+
+    amount = 10**9
+    first_profit = int(5 * 10**9)
+    second_profit = int(10**9)
+
+    # We reset time to 1 to facilitate reporting
+    chain.pending_timestamp = 1
+    chain.mine(timestamp=chain.pending_timestamp)
+
+    vault = create_vault(asset, fee_manager=flexible_fee_manager)
+    strategy = create_strategy(vault)
+
+    # deposit assets to vault and prepare strategy
+    user_deposit(fish, vault, asset, amount)
+    add_strategy_to_vault(gov, strategy, vault)
+    add_debt_to_strategy(gov, strategy, vault, amount)
+
+    assert strategy.totalAssets() == amount
+
+    assert vault.price_per_share() / 10 ** vault.decimals() == 1.0
+
+    # We create a virtual profit
+    asset.transfer(strategy, first_profit, sender=fish)
+
+    assert vault.totalAssets() == amount
+    assert vault.total_debt() == amount
+    assert vault.total_idle() == 0
+    assert vault.price_per_share() / 10 ** vault.decimals() == 1.0
+
+    assert vault.profit_distribution_rate() == 0
+
+    # We call process_report at t_1
+    chain.pending_timestamp = days_to_secs(1)
+    chain.mine(timestamp=chain.pending_timestamp)
+
+    tx = vault.process_report(strategy, sender=gov)
+
+    event = list(tx.decode_logs(vault.StrategyReported))
+    assert len(event) == 1
+    assert event[0].gain == first_profit
+
+    # set up fee manager and fees
+    management_fee = 0
+    performance_fee = 20_000
+    set_fees_for_strategy(
+        gov, strategy, flexible_fee_manager, management_fee, performance_fee
+    )
+
+    chain.pending_timestamp = days_to_secs(3)
+    chain.mine(timestamp=chain.pending_timestamp)
+
+    dist_rate_before_fees = vault.profit_distribution_rate()
+    pps_before_fees = vault.price_per_share()
+
+    # We create a virtual profit
+    asset.transfer(strategy, second_profit, sender=fish)
+    tx = vault.process_report(strategy, sender=gov)
+
+    event = list(tx.decode_logs(vault.StrategyReported))
+    assert len(event) == 1
+    assert event[0].gain == second_profit
+
+    # Due to the fact that we were able to pay fees with profit, pps remains
+    assert vault.price_per_share() == pytest.approx(pps_before_fees, 1e-5)
+    # Fee Managers gets shares at pps price without affecting it
+    assert vault.balanceOf(flexible_fee_manager) == int(
+        vault.convertToShares(second_profit * 2)
+    )
+    # dist rate gets lowered, but there are still profits being distributed
+    assert vault.profit_distribution_rate() < dist_rate_before_fees
 
 
 def test_profit_distribution__one_gain_one_deposit_one_withdraw(


### PR DESCRIPTION
## Description

By subtracting fees from profit being locked, we were actually locking the fees for ever. Fees should not be reduced from profit, as they are being paid with dilution by issuing yvTokens

Fixes #64  (fix)

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
