### PR TITLE
feat: added target_debt

### DIFF
--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -533,10 +533,11 @@ def _migrate_strategy(new_strategy: address, old_strategy: address):
 # DEBT MANAGEMENT #
 # TODO: allow the caller to specify the debt for the strategy, enforcing max_debt
 @internal
-def _update_debt(strategy: address) -> uint256:
+def _update_debt(strategy: address, target_debt: uint256) -> uint256:
     """
-    The vault will rebalance the debt vs its target debt (max_debt). This function will compare the current debt with 
-    the target debt and will take funds or deposit new funds to the strategy. 
+    The vault will rebalance the debt vs target debt. Target debt must be smaller or equal strategy max_debt.
+    This function will compare the current debt with the target debt and will take funds or deposit new 
+    funds to the strategy. 
 
     The strategy can require a minimum (or a maximum) amount of funds that it wants to receive to invest. 
     The strategy can also reject freeing funds if they are locked.
@@ -545,14 +546,17 @@ def _update_debt(strategy: address) -> uint256:
     """
 
     self._enforce_role(msg.sender, Roles.DEBT_MANAGER)
+
+    new_debt: uint256 = target_debt
+    # Revert if target_debt cannot be achieved due to configured max_debt for given strategy
+    assert new_debt <= self.strategies[strategy].max_debt, "new debt higher than max debt"
+
     # TODO: evaluate consequences of a strategy returning all the funds (including last reported profit) when the profit is not unlocked yet
     current_debt: uint256 = self.strategies[strategy].current_debt
 
     min_desired_debt: uint256 = 0
     max_desired_debt: uint256 = 0
     min_desired_debt, max_desired_debt = IStrategy(strategy).investable()
-
-    new_debt: uint256 = self.strategies[strategy].max_debt
 
     if self.shutdown:
         new_debt = 0
@@ -872,9 +876,9 @@ def update_max_debt_for_strategy(strategy: address, new_max_debt: uint256):
     log UpdatedMaxDebtForStrategy(msg.sender, strategy, new_max_debt)
 
 @external
-def update_debt(strategy: address) -> uint256:
+def update_debt(strategy: address, target_debt: uint256) -> uint256:
     self._enforce_role(msg.sender, Roles.DEBT_MANAGER)
-    return self._update_debt(strategy)
+    return self._update_debt(strategy, target_debt)
 
 ## EMERGENCY MANAGEMENT ##
 @external

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -308,9 +308,9 @@ def add_strategy_to_vault():
 # used to add debt to a strategy
 @pytest.fixture(scope="session")
 def add_debt_to_strategy():
-    def add_debt_to_strategy(user, strategy, vault, max_debt: int):
-        vault.update_max_debt_for_strategy(strategy.address, max_debt, sender=user)
-        vault.update_debt(strategy.address, sender=user)
+    def add_debt_to_strategy(user, strategy, vault, target_debt: int):
+        vault.update_max_debt_for_strategy(strategy.address, target_debt, sender=user)
+        vault.update_debt(strategy.address, target_debt, sender=user)
 
     return add_debt_to_strategy
 

--- a/tests/unit/vault/test_debt_management.py
+++ b/tests/unit/vault/test_debt_management.py
@@ -28,6 +28,18 @@ def test_update_debt__without_permission__reverts():
     pass
 
 
+def test_update_debt__with_strategy_max_debt_less_than_new_debt__reverts(
+    gov, asset, vault, strategy
+):
+    vault_balance = asset.balanceOf(vault)
+    new_debt = vault_balance // 2
+
+    vault.update_max_debt_for_strategy(strategy.address, new_debt, sender=gov)
+
+    with ape.reverts("new debt higher than max debt"):
+        vault.update_debt(strategy.address, new_debt + 1, sender=gov)
+
+
 def test_update_debt__with_current_debt_less_than_new_debt(gov, asset, vault, strategy):
     vault_balance = asset.balanceOf(vault)
     new_debt = vault_balance // 2
@@ -38,7 +50,7 @@ def test_update_debt__with_current_debt_less_than_new_debt(gov, asset, vault, st
 
     vault.update_max_debt_for_strategy(strategy.address, new_debt, sender=gov)
 
-    tx = vault.update_debt(strategy.address, sender=gov)
+    tx = vault.update_debt(strategy.address, new_debt, sender=gov)
     event = list(tx.decode_logs(vault.DebtUpdated))
 
     assert len(event) == 1
@@ -62,7 +74,7 @@ def test_update_debt__with_current_debt_equal_to_new_debt__reverts(
     add_debt_to_strategy(gov, strategy, vault, new_debt)
 
     with ape.reverts("new debt equals current debt"):
-        vault.update_debt(strategy.address, sender=gov)
+        vault.update_debt(strategy.address, new_debt, sender=gov)
 
 
 def test_update_debt__with_current_debt_greater_than_new_debt_and_zero_withdrawable__reverts(
@@ -79,7 +91,7 @@ def test_update_debt__with_current_debt_greater_than_new_debt_and_zero_withdrawa
     vault.update_max_debt_for_strategy(locked_strategy.address, new_debt, sender=gov)
 
     with ape.reverts("nothing to withdraw"):
-        vault.update_debt(locked_strategy.address, sender=gov)
+        vault.update_debt(locked_strategy.address, new_debt, sender=gov)
 
 
 def test_update_debt__with_current_debt_greater_than_new_debt_and_insufficient_withdrawable(
@@ -100,7 +112,7 @@ def test_update_debt__with_current_debt_greater_than_new_debt_and_insufficient_w
     initial_idle = vault.total_idle()
     initial_debt = vault.total_debt()
 
-    tx = vault.update_debt(locked_strategy.address, sender=gov)
+    tx = vault.update_debt(locked_strategy.address, new_debt, sender=gov)
     event = list(tx.decode_logs(vault.DebtUpdated))
 
     assert len(event) == 1
@@ -129,7 +141,7 @@ def test_update_debt__with_current_debt_greater_than_new_debt_and_sufficient_wit
     # reduce debt in strategy
     vault.update_max_debt_for_strategy(strategy.address, new_debt, sender=gov)
 
-    tx = vault.update_debt(strategy.address, sender=gov)
+    tx = vault.update_debt(strategy.address, new_debt, sender=gov)
     event = list(tx.decode_logs(vault.DebtUpdated))
 
     assert len(event) == 1
@@ -159,7 +171,7 @@ def test_update_debt__with_new_debt_greater_than_max_desired_debt(
     strategy.setMaxDebt(max_desired_debt, sender=gov)
 
     # update debt
-    tx = vault.update_debt(strategy.address, sender=gov)
+    tx = vault.update_debt(strategy.address, max_debt, sender=gov)
     event = list(tx.decode_logs(vault.DebtUpdated))
 
     assert len(event) == 1
@@ -190,7 +202,7 @@ def test_update_debt__with_new_debt_less_than_min_desired_debt__reverts(
     strategy.setMinDebt(min_desired_debt, sender=gov)
 
     with ape.reverts("new debt less than min debt"):
-        vault.update_debt(strategy.address, sender=gov)
+        vault.update_debt(strategy.address, new_debt, sender=gov)
 
 
 @pytest.mark.parametrize("minimum_total_idle", [0, 10**21])
@@ -238,7 +250,7 @@ def test_update_debt__with_current_debt_less_than_new_debt_and_minimum_total_idl
     # increase debt in strategy
     vault.update_max_debt_for_strategy(strategy.address, new_debt, sender=gov)
 
-    tx = vault.update_debt(strategy.address, sender=gov)
+    tx = vault.update_debt(strategy.address, new_debt, sender=gov)
     event = list(tx.decode_logs(vault.DebtUpdated))
 
     assert len(event) == 1
@@ -274,7 +286,7 @@ def test_update_debt__with_current_debt_less_than_new_debt_and_total_idle_lower_
     vault.update_max_debt_for_strategy(strategy.address, new_debt, sender=gov)
 
     with ape.reverts("no funds to deposit"):
-        vault.update_debt(strategy.address, sender=gov)
+        vault.update_debt(strategy.address, new_debt, sender=gov)
 
 
 def test_update_debt__with_current_debt_less_than_new_debt_and_minimum_total_idle_reducing_new_debt(
@@ -303,7 +315,7 @@ def test_update_debt__with_current_debt_less_than_new_debt_and_minimum_total_idl
     # increase debt in strategy
     vault.update_max_debt_for_strategy(strategy.address, new_debt, sender=gov)
 
-    tx = vault.update_debt(strategy.address, sender=gov)
+    tx = vault.update_debt(strategy.address, new_debt, sender=gov)
     event = list(tx.decode_logs(vault.DebtUpdated))
 
     assert len(event) == 1
@@ -345,7 +357,7 @@ def test_update_debt__with_current_debt_greater_than_new_debt_and_minimum_total_
     # reduce debt in strategy
     vault.update_max_debt_for_strategy(strategy.address, new_debt, sender=gov)
 
-    tx = vault.update_debt(strategy.address, sender=gov)
+    tx = vault.update_debt(strategy.address, new_debt, sender=gov)
     event = list(tx.decode_logs(vault.DebtUpdated))
 
     assert len(event) == 1
@@ -391,7 +403,7 @@ def test_update_debt__with_current_debt_greater_than_new_debt_and_total_idle_les
     # reduce debt in strategy
     vault.update_max_debt_for_strategy(strategy.address, new_debt, sender=gov)
 
-    tx = vault.update_debt(strategy.address, sender=gov)
+    tx = vault.update_debt(strategy.address, new_debt, sender=gov)
     event = list(tx.decode_logs(vault.DebtUpdated))
 
     assert len(event) == 1

--- a/tests/unit/vault/test_emergency_shutdown.py
+++ b/tests/unit/vault/test_emergency_shutdown.py
@@ -54,6 +54,6 @@ def test_strategy_return_funds(
     assert asset.balanceOf(strategy) == vault_balance
     assert asset.balanceOf(vault) == 0
     vault.shutdown_vault(sender=gov)
-    vault.update_debt(strategy.address, sender=gov)
+    vault.update_debt(strategy.address, 0, sender=gov)
     assert asset.balanceOf(strategy) == 0
     assert asset.balanceOf(vault) == vault_balance

--- a/tests/unit/vault/test_role_base_access.py
+++ b/tests/unit/vault/test_role_base_access.py
@@ -106,7 +106,7 @@ def test_update_max_debt__debt_manager(gov, vault, strategy, bunny):
 
 def test_update_debt__no_debt_manager__reverts(vault, strategy, bunny):
     with ape.reverts():
-        vault.update_debt(strategy, sender=bunny)
+        vault.update_debt(strategy, 10**18, sender=bunny)
 
 
 def test_update_debt__debt_manager(
@@ -121,7 +121,7 @@ def test_update_debt__debt_manager(
     max_debt_for_strategy = 1
     vault.update_max_debt_for_strategy(strategy, max_debt_for_strategy, sender=bunny)
 
-    tx = vault.update_debt(strategy, sender=bunny)
+    tx = vault.update_debt(strategy, max_debt_for_strategy, sender=bunny)
 
     event = list(tx.decode_logs(vault.DebtUpdated))
     assert len(event) == 1


### PR DESCRIPTION
## Description

Added target_debt to update_debt function. 

If `target_debt` is higher than `max_debt` configured for given strategy, function will revert, as it cannot fulfill exact required debt. That way we ensure that whatever value DEBT ALLOCATOR has computed/optimized its only applied if its within strategy parameters, otherwise a different debt value would be applied, which is not optimized.

Fixes #77 

## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
