### PR TITLE
chore: added parametrisation to test different types of tokens

### DIFF
--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -302,6 +302,23 @@ def _convert_to_shares(assets: uint256) -> uint256:
 
 # TODO: review in detail
 @internal
+def erc20_safe_approve(token: address, spender: address, amount: uint256):
+    # Used only to send tokens that are not the type managed by this Vault.
+    # HACK: Used to handle non-compliant tokens like USDT
+    response: Bytes[32] = raw_call(
+        token,
+        concat(
+            method_id("approve(address,uint256)"),
+            convert(spender, bytes32),
+            convert(amount, bytes32),
+        ),
+        max_outsize=32,
+    )
+    if len(response) > 0:
+        assert convert(response, bool), "Transfer failed!"
+
+
+@internal
 def erc20_safe_transfer_from(token: address, sender: address, receiver: address, amount: uint256):
     # Used only to send tokens that are not the type managed by this Vault.
     # HACK: Used to handle non-compliant tokens like USDT
@@ -659,9 +676,9 @@ def _update_debt(strategy: address, target_debt: uint256) -> uint256:
             assets_to_transfer = available_idle
             new_debt = current_debt + assets_to_transfer
         if assets_to_transfer > 0:
-            ASSET.approve(strategy, assets_to_transfer)
+            self.erc20_safe_approve(ASSET.address, strategy, assets_to_transfer)
             IStrategy(strategy).deposit(assets_to_transfer, self)
-            ASSET.approve(strategy, 0)
+            self.erc20_safe_approve(ASSET.address, strategy, 0)
             self.total_idle -= assets_to_transfer
             self.total_debt_ += assets_to_transfer
 
@@ -772,7 +789,7 @@ def _process_report(strategy: address) -> (uint256, uint256):
     if total_refunds > 0:
         # Accountant should approve transfer of assets
         total_refunds = min(total_refunds, ASSET.balanceOf(accountant))
-        ASSET.transferFrom(self.accountant, self, total_refunds)
+        self.erc20_safe_transfer_from(ASSET.address, self.accountant, self, total_refunds)
         # Assets coming from refunds are allocated as total_idle
         self.total_idle += total_refunds
 
@@ -910,7 +927,7 @@ def sweep(token: address) -> (uint256):
     else:
         amount = ERC20(token).balanceOf(self)
     assert amount != 0, "no dust"
-    ERC20(token).transfer(msg.sender, amount)
+    self.erc20_safe_transfer(ASSET.address, msg.sender, amount)
     log Sweep(token, amount)
     return amount
 

--- a/contracts/test/ERC4626BaseStrategy.sol
+++ b/contracts/test/ERC4626BaseStrategy.sol
@@ -26,8 +26,8 @@ abstract contract ERC4626BaseStrategy is IStrategyERC4626, ERC4626 {
         _decimals = IERC20Metadata(address(_asset)).decimals();
 
         vault = _vault;
-        // using approve since initialization is only called once
-        IERC20(_asset).approve(_vault, type(uint256).max); // Give Vault unlimited access (might save gas)
+        //        // using approve since initialization is only called once
+        //        IERC20(_asset).approve(_vault, type(uint256).max); // Give Vault unlimited access (might save gas)
     }
 
     /** @dev See {IERC20Metadata-decimals}. */

--- a/contracts/test/ERC4626BaseStrategy.sol
+++ b/contracts/test/ERC4626BaseStrategy.sol
@@ -8,11 +8,13 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IVault} from "../interfaces/IVault.sol";
 import {IStrategyERC4626} from "../interfaces/IStrategyERC4626.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 abstract contract ERC4626BaseStrategy is IStrategyERC4626, ERC4626 {
     using SafeERC20 for IERC20;
 
     address public override vault;
+    uint8 private _decimals;
 
     constructor(address _vault, address _asset)
         ERC4626(IERC20Metadata(address(_asset)))
@@ -21,9 +23,22 @@ abstract contract ERC4626BaseStrategy is IStrategyERC4626, ERC4626 {
     }
 
     function _initialize(address _vault, address _asset) internal {
+        _decimals = IERC20Metadata(address(_asset)).decimals();
+
         vault = _vault;
         // using approve since initialization is only called once
         IERC20(_asset).approve(_vault, type(uint256).max); // Give Vault unlimited access (might save gas)
+    }
+
+    /** @dev See {IERC20Metadata-decimals}. */
+    function decimals()
+        public
+        view
+        virtual
+        override(ERC20, IERC20Metadata)
+        returns (uint8)
+    {
+        return _decimals;
     }
 
     // TODO: add roles (including vault)

--- a/contracts/test/Token.sol
+++ b/contracts/test/Token.sol
@@ -4,7 +4,15 @@ pragma solidity 0.8.14;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract Token is ERC20 {
-    constructor(string memory _name) ERC20(_name, _name) {}
+    uint8 public _decimals;
+
+    constructor(string memory _name, uint8 decimals) ERC20(_name, _name) {
+        _decimals = decimals;
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return _decimals;
+    }
 
     function mint(address _to, uint256 _amount) external {
         _mint(_to, _amount);

--- a/contracts/test/Token.sol
+++ b/contracts/test/Token.sol
@@ -4,14 +4,14 @@ pragma solidity 0.8.14;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract Token is ERC20 {
-    uint8 public _decimals;
+    uint8 public decimals_;
 
-    constructor(string memory _name, uint8 decimals) ERC20(_name, _name) {
-        _decimals = decimals;
+    constructor(string memory _name, uint8 _decimals) ERC20(_name, _name) {
+        decimals_ = _decimals;
     }
 
     function decimals() public view virtual override returns (uint8) {
-        return _decimals;
+        return decimals_;
     }
 
     function mint(address _to, uint256 _amount) external {

--- a/contracts/test/USDT.sol
+++ b/contracts/test/USDT.sol
@@ -1,0 +1,557 @@
+/**
+ *Submitted for verification at Etherscan.io on 2017-11-28
+ */
+
+pragma solidity ^0.4.17;
+
+/**
+ * @title SafeMath
+ * @dev Math operations with safety checks that throw on error
+ */
+library SafeMath {
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        if (a == 0) {
+            return 0;
+        }
+        uint256 c = a * b;
+        assert(c / a == b);
+        return c;
+    }
+
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        // assert(b > 0); // Solidity automatically throws when dividing by 0
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+        return c;
+    }
+
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        assert(b <= a);
+        return a - b;
+    }
+
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        assert(c >= a);
+        return c;
+    }
+}
+
+/**
+ * @title Ownable
+ * @dev The Ownable contract has an owner address, and provides basic authorization control
+ * functions, this simplifies the implementation of "user permissions".
+ */
+contract Ownable {
+    address public owner;
+
+    /**
+     * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+     * account.
+     */
+    function Ownable() public {
+        owner = msg.sender;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to transfer control of the contract to a newOwner.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        if (newOwner != address(0)) {
+            owner = newOwner;
+        }
+    }
+}
+
+/**
+ * @title ERC20Basic
+ * @dev Simpler version of ERC20 interface
+ * @dev see https://github.com/ethereum/EIPs/issues/20
+ */
+contract ERC20Basic {
+    uint256 public _totalSupply;
+
+    function totalSupply() public constant returns (uint256);
+
+    function balanceOf(address who) public constant returns (uint256);
+
+    function transfer(address to, uint256 value) public;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+}
+
+/**
+ * @title ERC20 interface
+ * @dev see https://github.com/ethereum/EIPs/issues/20
+ */
+contract ERC20 is ERC20Basic {
+    function allowance(address owner, address spender)
+        public
+        constant
+        returns (uint256);
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 value
+    ) public;
+
+    function approve(address spender, uint256 value) public;
+
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 value
+    );
+}
+
+/**
+ * @title Basic token
+ * @dev Basic version of StandardToken, with no allowances.
+ */
+contract BasicToken is Ownable, ERC20Basic {
+    using SafeMath for uint256;
+
+    mapping(address => uint256) public balances;
+
+    // additional variables for use if transaction fees ever became necessary
+    uint256 public basisPointsRate = 0;
+    uint256 public maximumFee = 0;
+
+    /**
+     * @dev Fix for the ERC20 short address attack.
+     */
+    modifier onlyPayloadSize(uint256 size) {
+        require(!(msg.data.length < size + 4));
+        _;
+    }
+
+    /**
+     * @dev transfer token for a specified address
+     * @param _to The address to transfer to.
+     * @param _value The amount to be transferred.
+     */
+
+    // Test easiest code
+    function transfer_2(address _to, uint256 _value) {
+        balances[msg.sender] = balances[msg.sender].sub(_value);
+        balances[_to] = balances[_to].add(_value);
+        Transfer(msg.sender, _to, _value);
+    }
+
+    // Check vars
+    function transfer_3(address _to, uint256 _value)
+        public
+        onlyPayloadSize(2 * 32)
+    {
+        Transfer(msg.sender, _to, _value);
+    }
+
+    function transfer(address _to, uint256 _value)
+        public
+        onlyPayloadSize(2 * 32)
+    {
+        uint256 fee = (_value.mul(basisPointsRate)).div(10000);
+        if (fee > maximumFee) {
+            fee = maximumFee;
+        }
+        uint256 sendAmount = _value.sub(fee);
+        balances[msg.sender] = balances[msg.sender].sub(_value);
+        balances[_to] = balances[_to].add(sendAmount);
+        if (fee > 0) {
+            balances[owner] = balances[owner].add(fee);
+            Transfer(msg.sender, owner, fee);
+        }
+        Transfer(msg.sender, _to, sendAmount);
+    }
+
+    /**
+     * @dev Gets the balance of the specified address.
+     * @param _owner The address to query the the balance of.
+     * @return An uint representing the amount owned by the passed address.
+     */
+    function balanceOf(address _owner)
+        public
+        constant
+        returns (uint256 balance)
+    {
+        return balances[_owner];
+    }
+}
+
+/**
+ * @title Standard ERC20 token
+ *
+ * @dev Implementation of the basic standard token.
+ * @dev https://github.com/ethereum/EIPs/issues/20
+ * @dev Based oncode by FirstBlood: https://github.com/Firstbloodio/token/blob/master/smart_contract/FirstBloodToken.sol
+ */
+contract StandardToken is BasicToken, ERC20 {
+    mapping(address => mapping(address => uint256)) public allowed;
+
+    uint256 public constant MAX_UINT = 2**256 - 1;
+
+    /**
+     * @dev Transfer tokens from one address to another
+     * @param _from address The address which you want to send tokens from
+     * @param _to address The address which you want to transfer to
+     * @param _value uint the amount of tokens to be transferred
+     */
+    function transferFrom(
+        address _from,
+        address _to,
+        uint256 _value
+    ) public onlyPayloadSize(3 * 32) {
+        var _allowance = allowed[_from][msg.sender];
+
+        // Check is not needed because sub(_allowance, _value) will already throw if this condition is not met
+        // if (_value > _allowance) throw;
+
+        uint256 fee = (_value.mul(basisPointsRate)).div(10000);
+        if (fee > maximumFee) {
+            fee = maximumFee;
+        }
+        if (_allowance < MAX_UINT) {
+            allowed[_from][msg.sender] = _allowance.sub(_value);
+        }
+        uint256 sendAmount = _value.sub(fee);
+        balances[_from] = balances[_from].sub(_value);
+        balances[_to] = balances[_to].add(sendAmount);
+        if (fee > 0) {
+            balances[owner] = balances[owner].add(fee);
+            Transfer(_from, owner, fee);
+        }
+        Transfer(_from, _to, sendAmount);
+    }
+
+    /**
+     * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
+     * @param _spender The address which will spend the funds.
+     * @param _value The amount of tokens to be spent.
+     */
+    function approve(address _spender, uint256 _value)
+        public
+        onlyPayloadSize(2 * 32)
+    {
+        // To change the approve amount you first have to reduce the addresses`
+        //  allowance to zero by calling `approve(_spender, 0)` if it is not
+        //  already 0 to mitigate the race condition described here:
+        //  https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+        require(!((_value != 0) && (allowed[msg.sender][_spender] != 0)));
+
+        allowed[msg.sender][_spender] = _value;
+        Approval(msg.sender, _spender, _value);
+    }
+
+    /**
+     * @dev Function to check the amount of tokens than an owner allowed to a spender.
+     * @param _owner address The address which owns the funds.
+     * @param _spender address The address which will spend the funds.
+     * @return A uint specifying the amount of tokens still available for the spender.
+     */
+    function allowance(address _owner, address _spender)
+        public
+        constant
+        returns (uint256 remaining)
+    {
+        return allowed[_owner][_spender];
+    }
+}
+
+/**
+ * @title Pausable
+ * @dev Base contract which allows children to implement an emergency stop mechanism.
+ */
+contract Pausable is Ownable {
+    event Pause();
+    event Unpause();
+
+    bool public paused = false;
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     */
+    modifier whenNotPaused() {
+        require(!paused);
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     */
+    modifier whenPaused() {
+        require(paused);
+        _;
+    }
+
+    /**
+     * @dev called by the owner to pause, triggers stopped state
+     */
+    function pause() public onlyOwner whenNotPaused {
+        paused = true;
+        Pause();
+    }
+
+    /**
+     * @dev called by the owner to unpause, returns to normal state
+     */
+    function unpause() public onlyOwner whenPaused {
+        paused = false;
+        Unpause();
+    }
+}
+
+contract BlackList is Ownable, BasicToken {
+    /////// Getters to allow the same blacklist to be used also by other contracts (including upgraded Tether) ///////
+    function getBlackListStatus(address _maker)
+        external
+        constant
+        returns (bool)
+    {
+        return isBlackListed[_maker];
+    }
+
+    function getOwner() external constant returns (address) {
+        return owner;
+    }
+
+    mapping(address => bool) public isBlackListed;
+
+    function addBlackList(address _evilUser) public onlyOwner {
+        isBlackListed[_evilUser] = true;
+        AddedBlackList(_evilUser);
+    }
+
+    function removeBlackList(address _clearedUser) public onlyOwner {
+        isBlackListed[_clearedUser] = false;
+        RemovedBlackList(_clearedUser);
+    }
+
+    function destroyBlackFunds(address _blackListedUser) public onlyOwner {
+        require(isBlackListed[_blackListedUser]);
+        uint256 dirtyFunds = balanceOf(_blackListedUser);
+        balances[_blackListedUser] = 0;
+        _totalSupply -= dirtyFunds;
+        DestroyedBlackFunds(_blackListedUser, dirtyFunds);
+    }
+
+    event DestroyedBlackFunds(address _blackListedUser, uint256 _balance);
+
+    event AddedBlackList(address _user);
+
+    event RemovedBlackList(address _user);
+}
+
+contract UpgradedStandardToken is StandardToken {
+    // those methods are called by the legacy contract
+    // and they must ensure msg.sender to be the contract address
+    function transferByLegacy(
+        address from,
+        address to,
+        uint256 value
+    ) public;
+
+    function transferFromByLegacy(
+        address sender,
+        address from,
+        address spender,
+        uint256 value
+    ) public;
+
+    function approveByLegacy(
+        address from,
+        address spender,
+        uint256 value
+    ) public;
+}
+
+contract TetherToken is Pausable, StandardToken, BlackList {
+    string public name;
+    string public symbol;
+    uint256 public decimals;
+    address public upgradedAddress;
+    bool public deprecated;
+
+    //  The contract can be initialized with a number of tokens
+    //  All the tokens are deposited to the owner address
+    //
+    // @param _balance Initial supply of the contract
+    // @param _name Token Name
+    // @param _symbol Token symbol
+    // @param _decimals Token decimals
+    function TetherToken(
+        uint256 _initialSupply,
+        string _name,
+        string _symbol,
+        uint256 _decimals
+    ) public {
+        _totalSupply = _initialSupply;
+        name = _name;
+        symbol = _symbol;
+        decimals = _decimals;
+        balances[owner] = _initialSupply;
+        deprecated = false;
+    }
+
+    // Forward ERC20 methods to upgraded contract if this one is deprecated
+    function transfer(address _to, uint256 _value) public whenNotPaused {
+        require(!isBlackListed[msg.sender]);
+        if (deprecated) {
+            return
+                UpgradedStandardToken(upgradedAddress).transferByLegacy(
+                    msg.sender,
+                    _to,
+                    _value
+                );
+        } else {
+            return super.transfer(_to, _value);
+        }
+    }
+
+    // Forward ERC20 methods to upgraded contract if this one is deprecated
+    function transferFrom(
+        address _from,
+        address _to,
+        uint256 _value
+    ) public whenNotPaused {
+        require(!isBlackListed[_from]);
+        if (deprecated) {
+            return
+                UpgradedStandardToken(upgradedAddress).transferFromByLegacy(
+                    msg.sender,
+                    _from,
+                    _to,
+                    _value
+                );
+        } else {
+            return super.transferFrom(_from, _to, _value);
+        }
+    }
+
+    // Forward ERC20 methods to upgraded contract if this one is deprecated
+    function balanceOf(address who) public constant returns (uint256) {
+        if (deprecated) {
+            return UpgradedStandardToken(upgradedAddress).balanceOf(who);
+        } else {
+            return super.balanceOf(who);
+        }
+    }
+
+    // Forward ERC20 methods to upgraded contract if this one is deprecated
+    function approve(address _spender, uint256 _value)
+        public
+        onlyPayloadSize(2 * 32)
+    {
+        if (deprecated) {
+            return
+                UpgradedStandardToken(upgradedAddress).approveByLegacy(
+                    msg.sender,
+                    _spender,
+                    _value
+                );
+        } else {
+            return super.approve(_spender, _value);
+        }
+    }
+
+    // Forward ERC20 methods to upgraded contract if this one is deprecated
+    function allowance(address _owner, address _spender)
+        public
+        constant
+        returns (uint256 remaining)
+    {
+        if (deprecated) {
+            return StandardToken(upgradedAddress).allowance(_owner, _spender);
+        } else {
+            return super.allowance(_owner, _spender);
+        }
+    }
+
+    // deprecate current contract in favour of a new one
+    function deprecate(address _upgradedAddress) public onlyOwner {
+        deprecated = true;
+        upgradedAddress = _upgradedAddress;
+        Deprecate(_upgradedAddress);
+    }
+
+    // deprecate current contract if favour of a new one
+    function totalSupply() public constant returns (uint256) {
+        if (deprecated) {
+            return StandardToken(upgradedAddress).totalSupply();
+        } else {
+            return _totalSupply;
+        }
+    }
+
+    // To be used in conftest with other tokens
+    function mint(address receiver, uint256 amount) public onlyOwner {
+        require(_totalSupply + amount > _totalSupply);
+        require(balances[receiver] + amount > balances[receiver]);
+
+        balances[receiver] += amount;
+        _totalSupply += amount;
+        Issue(amount);
+    }
+
+    // Issue a new amount of tokens
+    // these tokens are deposited into the owner address
+    //
+    // @param _amount Number of tokens to be issued
+    function issue(uint256 amount) public onlyOwner {
+        require(_totalSupply + amount > _totalSupply);
+        require(balances[owner] + amount > balances[owner]);
+
+        balances[owner] += amount;
+        _totalSupply += amount;
+        Issue(amount);
+    }
+
+    // Redeem tokens.
+    // These tokens are withdrawn from the owner address
+    // if the balance must be enough to cover the redeem
+    // or the call will fail.
+    // @param _amount Number of tokens to be issued
+    function redeem(uint256 amount) public onlyOwner {
+        require(_totalSupply >= amount);
+        require(balances[owner] >= amount);
+
+        _totalSupply -= amount;
+        balances[owner] -= amount;
+        Redeem(amount);
+    }
+
+    function setParams(uint256 newBasisPoints, uint256 newMaxFee)
+        public
+        onlyOwner
+    {
+        // Ensure transparency by hardcoding limit beyond which fees can never be added
+        require(newBasisPoints < 20);
+        require(newMaxFee < 50);
+
+        basisPointsRate = newBasisPoints;
+        maximumFee = newMaxFee.mul(10**decimals);
+
+        Params(basisPointsRate, maximumFee);
+    }
+
+    // Called when new token are issued
+    event Issue(uint256 amount);
+
+    // Called when tokens are redeemed
+    event Redeem(uint256 amount);
+
+    // Called when contract is deprecated
+    event Deprecate(address newAddress);
+
+    // Called if contract ever adds fees
+    event Params(uint256 feeBasisPoints, uint256 maxFee);
+}

--- a/contracts/test/mocks/ERC4626/LiquidStrategy.sol
+++ b/contracts/test/mocks/ERC4626/LiquidStrategy.sol
@@ -19,7 +19,12 @@ contract ERC4626LiquidStrategy is ERC4626BaseStrategyMock {
         _amountFreed = IERC20(asset()).balanceOf(address(this));
     }
 
-    function maxWithdraw(address owner) public view override returns (uint256) {
-        return _convertToAssets(balanceOf(owner), Math.Rounding.Down);
+    function maxWithdraw(address _owner)
+        public
+        view
+        override
+        returns (uint256)
+    {
+        return _convertToAssets(balanceOf(_owner), Math.Rounding.Down);
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,14 @@ def gov(accounts):
 
 
 @pytest.fixture(scope="session")
-def fish_amount():
-    yield 10**18
+def fish_amount(asset):
+    # Working always with 10_000.00
+    yield 10 ** (asset.decimals() + 4)
+
+
+@pytest.fixture(scope="session")
+def half_fish_amount(fish_amount):
+    yield fish_amount // 2
 
 
 @pytest.fixture(scope="session")
@@ -26,8 +32,9 @@ def fish(accounts, asset, gov, fish_amount):
 
 
 @pytest.fixture(scope="session")
-def whale_amount():
-    yield 10**22
+def whale_amount(asset):
+    # Working always with 1_000_000.00
+    yield 10 ** (asset.decimals() + 6)
 
 
 @pytest.fixture(scope="session")
@@ -82,10 +89,18 @@ def keeper(accounts):
     yield accounts[11]
 
 
-# use this for general asset mock
-@pytest.fixture(scope="session")
-def asset(create_token):
-    return create_token("asset")
+# TODO: uncomment decimals to check different tokens
+@pytest.fixture(
+    scope="session",
+    params=[
+        # 18,
+        # 8,
+        6
+    ],
+)
+def asset(create_token, request):
+    decimals = request.param
+    return create_token("asset", decimals)
 
 
 # use this for token mock
@@ -97,8 +112,8 @@ def mock_token(create_token):
 # use this to create other tokens
 @pytest.fixture(scope="session")
 def create_token(project, gov):
-    def create_token(name):
-        return gov.deploy(project.Token, name)
+    def create_token(name, decimals=18):
+        return gov.deploy(project.Token, name, decimals)
 
     yield create_token
 

--- a/tests/e2e/test_lossy_strategy_flow.py
+++ b/tests/e2e/test_lossy_strategy_flow.py
@@ -83,7 +83,7 @@ def test_lossy_strategy_flow(
     assert vault.totalAssets() == 2 * deposit_amount - first_loss - second_loss
     assert vault.total_idle() == 0
 
-    # Les set a `minimum_total_idle` value
+    # Lets set a `minimum_total_idle` value
     vault.set_minimum_total_idle(3 * deposit_amount // 4, sender=gov)
 
     # we allowed more debt than `minimum_total_idle` allows us, to ensure `update_debt`

--- a/tests/e2e/test_lossy_strategy_flow.py
+++ b/tests/e2e/test_lossy_strategy_flow.py
@@ -35,7 +35,6 @@ def test_lossy_strategy_flow(
     assert vault.price_per_share() / 10 ** asset.decimals() == 1.0
 
     add_debt_to_strategy(gov, strategy, vault, deposit_amount)
-    assert strategy.totalSupply() == deposit_amount
     assert strategy.totalAssets() == deposit_amount
     assert strategy.balanceOf(vault) == deposit_amount
     assert vault.totalAssets() == deposit_amount

--- a/tests/unit/vault/test_erc4626.py
+++ b/tests/unit/vault/test_erc4626.py
@@ -40,14 +40,16 @@ def test_preview_deposit(asset, fish, fish_amount, create_vault, user_deposit):
     assert vault.previewDeposit(assets) == assets
 
 
-@pytest.mark.parametrize("deposit_limit", [10**18 // 2, 10**18])
+@pytest.mark.parametrize("deposit_limit", ["half_fish_amount", "fish_amount"])
 def test_max_deposit__with_total_assets_greater_than_or_equal_deposit_limit__returns_zero(
-    asset, fish, fish_amount, gov, create_vault, deposit_limit, user_deposit
+    asset, fish, fish_amount, gov, create_vault, deposit_limit, user_deposit, request
 ):
     vault = create_vault(asset)
     assets = fish_amount
 
     user_deposit(fish, vault, asset, assets)
+
+    deposit_limit = request.getfixturevalue(deposit_limit)
 
     vault.set_deposit_limit(deposit_limit, sender=gov)
 
@@ -76,14 +78,16 @@ def test_preview_mint(asset, fish, fish_amount, create_vault, user_deposit):
     assert vault.previewMint(shares) == shares
 
 
-@pytest.mark.parametrize("deposit_limit", [10**18 // 2, 10**18])
+@pytest.mark.parametrize("deposit_limit", ["half_fish_amount", "fish_amount"])
 def test_max_mint__with_total_assets_greater_than_or_equal_deposit_limit__returns_zero(
-    asset, fish, fish_amount, gov, create_vault, deposit_limit, user_deposit
+    asset, fish, fish_amount, gov, create_vault, deposit_limit, user_deposit, request
 ):
     vault = create_vault(asset)
     assets = fish_amount
 
     user_deposit(fish, vault, asset, assets)
+
+    deposit_limit = request.getfixturevalue(deposit_limit)
 
     vault.set_deposit_limit(deposit_limit, sender=gov)
 

--- a/tests/unit/vault/test_sweep.py
+++ b/tests/unit/vault/test_sweep.py
@@ -41,6 +41,7 @@ def test_sweep__with_asset_token__withdraws_airdrop_only(
     # add debt to strategy to check debt is accounted for
     add_debt_to_strategy(gov, strategy, vault, debt)
 
+    gov_balance = asset.balanceOf(gov)
     tx = vault.sweep(asset.address, sender=gov)
     event = list(tx.decode_logs(vault.Sweep))
 
@@ -48,14 +49,14 @@ def test_sweep__with_asset_token__withdraws_airdrop_only(
     assert event[0].token == asset.address
     assert event[0].amount == asset_airdrop
 
-    assert asset.balanceOf(gov) == asset_airdrop
+    assert asset.balanceOf(gov) == asset_airdrop + gov_balance
     assert asset.balanceOf(vault) == (vault_balance - debt)
     assert vault.totalAssets() == vault_balance
 
 
 def test_sweep__with_token__withdraws_token(
     gov,
-    mock_token,
+    asset,
     vault,
     strategy,
     mint_and_deposit_into_vault,
@@ -65,20 +66,21 @@ def test_sweep__with_token__withdraws_token(
     # create vault with strategy and debt allocated
     vault_balance = 10**22
     debt = vault_balance // 10
-    mock_token_airdop = vault_balance // 10
+    mock_token_airdrop = vault_balance // 10
     mint_and_deposit_into_vault(vault, gov, vault_balance)
     add_debt_to_strategy(gov, strategy, vault, debt)
 
     # airdrop random token to vault
-    airdrop_asset(gov, mock_token, vault, mock_token_airdop)
+    airdrop_asset(gov, asset, vault, mock_token_airdrop)
 
-    tx = vault.sweep(mock_token.address, sender=gov)
+    gov_balance = asset.balanceOf(gov)
+    tx = vault.sweep(asset.address, sender=gov)
     event = list(tx.decode_logs(vault.Sweep))
 
     assert len(event) == 1
-    assert event[0].token == mock_token.address
-    assert event[0].amount == mock_token_airdop
+    assert event[0].token == asset.address
+    assert event[0].amount == mock_token_airdrop
 
-    assert mock_token.balanceOf(gov) == mock_token_airdop
-    assert mock_token.balanceOf(vault) == 0
+    assert asset.balanceOf(gov) == mock_token_airdrop + gov_balance
+    assert asset.balanceOf(vault) == vault_balance - debt
     assert vault.totalAssets() == vault_balance


### PR DESCRIPTION
## Description

added parametrization to number of token decimals

parametrization is commented, but for one option, as pytest-xdist is not working with Ape and tests were taking too much time.

Fixes #95 

## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
