### PR TITLE
build: update migration to work with debt

### DIFF
--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -612,7 +612,7 @@ def _revoke_strategy(old_strategy: address):
 @internal
 def _migrate_strategy(new_strategy: address, old_strategy: address, call_migrate_strategy: bool):
     assert self.strategies[old_strategy].activation != 0, "old strategy not active"
-    assert self.strategies[old_strategy].current_debt == 0, "old strategy has debt"
+    assert self.strategies[old_strategy].current_debt == 0 or call_migrate_strategy, "old strategy has debt"
     assert new_strategy != empty(address), "strategy cannot be zero address"
     assert IStrategy(new_strategy).asset() == ASSET.address, "invalid asset"
     assert IStrategy(new_strategy).vault() == self, "invalid vault"
@@ -622,7 +622,8 @@ def _migrate_strategy(new_strategy: address, old_strategy: address, call_migrate
 
     if call_migrate_strategy:
       IStrategy(old_strategy).migrate(new_strategy)
-
+      # update old strategies debt so it can be revoked if the debt was migrated
+      self.strategies[old_strategy].current_debt = 0
 
     # NOTE: we add strategy with same params than the strategy being migrated
     self.strategies[new_strategy] = StrategyParams({
@@ -631,7 +632,7 @@ def _migrate_strategy(new_strategy: address, old_strategy: address, call_migrate
        current_debt: migrated_strategy.current_debt,
        max_debt: migrated_strategy.max_debt
        })
-
+    
     self._revoke_strategy(old_strategy)
 
     log StrategyMigrated(old_strategy, new_strategy)

--- a/contracts/test/mocks/ERC4626/BaseStrategyMock.sol
+++ b/contracts/test/mocks/ERC4626/BaseStrategyMock.sol
@@ -24,10 +24,6 @@ abstract contract ERC4626BaseStrategyMock is ERC4626BaseStrategy {
         emit Tend();
     }
 
-    function migrate(address newStrategy) external override {
-        IERC20(asset()).safeTransfer(newStrategy, IERC20(asset()).balanceOf(address(this)));
-    }
-
     function setMinDebt(uint256 _minDebt) external {
         minDebt = _minDebt;
     }

--- a/contracts/test/mocks/ERC4626/LiquidStrategy.sol
+++ b/contracts/test/mocks/ERC4626/LiquidStrategy.sol
@@ -2,10 +2,12 @@
 pragma solidity 0.8.14;
 
 import {ERC4626BaseStrategyMock, IERC20} from "./BaseStrategyMock.sol";
-
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract ERC4626LiquidStrategy is ERC4626BaseStrategyMock {
+    using SafeERC20 for IERC20;
+    
     constructor(address _vault, address _asset)
         ERC4626BaseStrategyMock(_vault, _asset)
     {}
@@ -26,5 +28,9 @@ contract ERC4626LiquidStrategy is ERC4626BaseStrategyMock {
         returns (uint256)
     {
         return _convertToAssets(balanceOf(_owner), Math.Rounding.Down);
+    }
+
+    function migrate(address newStrategy) external override {
+        IERC20(asset()).safeTransfer(newStrategy, IERC20(asset()).balanceOf(address(this)));
     }
 }

--- a/contracts/test/mocks/ERC4626/LockedStrategy.sol
+++ b/contracts/test/mocks/ERC4626/LockedStrategy.sol
@@ -2,8 +2,10 @@
 pragma solidity 0.8.14;
 
 import {ERC4626BaseStrategyMock, IERC20} from "./BaseStrategyMock.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract ERC4626LockedStrategy is ERC4626BaseStrategyMock {
+    using SafeERC20 for IERC20;
     // error for test function setLockedFunds
     error InsufficientFunds();
 
@@ -46,5 +48,10 @@ contract ERC4626LockedStrategy is ERC4626BaseStrategyMock {
             // no locked assets, withdraw all
             return balance;
         }
+    }
+
+    function migrate(address newStrategy) external override {
+        require(lockedBalance == 0, "strat not liquid");
+        IERC20(asset()).safeTransfer(newStrategy, IERC20(asset()).balanceOf(address(this)));
     }
 }

--- a/contracts/test/mocks/ERC4626/LossyStrategy.sol
+++ b/contracts/test/mocks/ERC4626/LossyStrategy.sol
@@ -57,4 +57,8 @@ contract ERC4626LossyStrategy is ERC4626BaseStrategyMock {
     function maxWithdraw(address) public view override returns (uint256) {
         return IERC20(asset()).balanceOf(address(this));
     }
+
+    function migrate(address newStrategy) external override {
+        IERC20(asset()).safeTransfer(newStrategy, IERC20(asset()).balanceOf(address(this)));
+    }
 }

--- a/tests/unit/vault/test_strategy_management.py
+++ b/tests/unit/vault/test_strategy_management.py
@@ -2,7 +2,8 @@ import ape
 import pytest
 from ape import chain
 from utils import checks
-from utils.constants import ROLES, ZERO_ADDRESS
+from utils.utils import sleep
+from utils.constants import ROLES, ZERO_ADDRESS, DAY
 
 
 def test_add_strategy__with_valid_strategy(chain, gov, vault, create_strategy):
@@ -112,7 +113,7 @@ def test_migrate_strategy__with_no_debt(chain, gov, vault, strategy, create_stra
     checks.check_revoked_strategy(old_strategy_params)
 
 
-def test_migrate_strategy__with_existing_debt(
+def test_migrate_strategy__with_existing_debt__reverts(
     gov,
     asset,
     vault,
@@ -130,7 +131,166 @@ def test_migrate_strategy__with_existing_debt(
     add_debt_to_strategy(gov, strategy, vault, new_debt)
 
     with ape.reverts("old strategy has debt"):
+        vault.migrate_strategy(new_strategy.address, old_strategy.address, False, sender=gov)
+    
+    
+def test_migrate_strategy__with_existing_debt__migrates(
+    gov,
+    asset,
+    vault,
+    strategy,
+    mint_and_deposit_into_vault,
+    create_strategy,
+    add_debt_to_strategy,
+):
+    mint_and_deposit_into_vault(vault)
+    vault_balance = asset.balanceOf(vault)
+    new_debt = vault_balance
+    old_strategy = strategy
+    new_strategy = create_strategy(vault)
+
+    add_debt_to_strategy(gov, strategy, vault, new_debt)
+
+    old_strategy_params = vault.strategies(old_strategy)
+    old_current_debt = old_strategy_params.current_debt
+    old_max_debt = old_strategy_params.max_debt
+
+    snapshot = chain.pending_timestamp
+    tx = vault.migrate_strategy(new_strategy.address, old_strategy.address, sender=gov)
+
+    event = list(tx.decode_logs(vault.StrategyMigrated))
+
+    assert len(event) == 1
+    assert event[0].old_strategy == old_strategy.address
+    assert event[0].new_strategy == new_strategy.address
+
+    new_strategy_params = vault.strategies(new_strategy)
+    assert new_strategy_params.activation == pytest.approx(snapshot, abs=1)
+    assert new_strategy_params.current_debt == old_current_debt
+    assert new_strategy_params.max_debt == old_max_debt
+    assert new_strategy_params.last_report == pytest.approx(snapshot, abs=1)
+
+    old_strategy_params = vault.strategies(old_strategy)
+    checks.check_revoked_strategy(old_strategy_params)
+    
+def test_migrate_locked_strategy__with_existing_debt__reverts(
+    gov,
+    asset,
+    user_deposit,
+    create_vault,
+    mint_and_deposit_into_vault,
+    create_locked_strategy,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+    fish_amount,
+    fish
+):  
+    vault = create_vault(asset)
+    locked_strategy = create_locked_strategy(vault)
+    amount = fish_amount
+    shares = amount
+
+    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
+    user_deposit(fish, vault, asset, amount)
+    add_strategy_to_vault(gov, locked_strategy, vault)
+    add_debt_to_strategy(gov, locked_strategy, vault, amount)
+
+    assert vault.totalAssets() == amount
+    assert vault.strategies(locked_strategy).current_debt == amount
+
+    amount_to_lock = amount // 2
+    locked_strategy.setLockedFunds(amount_to_lock, DAY, sender=gov)
+    assert locked_strategy.lockedBalance() == amount_to_lock
+
+    old_strategy = locked_strategy
+    new_strategy = create_locked_strategy(vault)
+
+    with ape.reverts("strat not liquid"):
         vault.migrate_strategy(new_strategy.address, old_strategy.address, sender=gov)
+
+    # wait the lock period of time and we should be able to migrate
+    sleep(DAY + 1)
+
+    # unlock funds
+    locked_strategy.freeLockedFunds(sender=gov)
+
+    old_strategy_params = vault.strategies(old_strategy)
+    old_current_debt = old_strategy_params.current_debt
+    old_max_debt = old_strategy_params.max_debt
+
+    snapshot = chain.pending_timestamp
+    tx = vault.migrate_strategy(new_strategy.address, old_strategy.address, sender=gov)
+
+    event = list(tx.decode_logs(vault.StrategyMigrated))
+
+    assert len(event) == 1
+    assert event[0].old_strategy == old_strategy.address
+    assert event[0].new_strategy == new_strategy.address
+
+    new_strategy_params = vault.strategies(new_strategy)
+    assert new_strategy_params.activation == pytest.approx(snapshot, abs=1)
+    assert new_strategy_params.current_debt == old_current_debt
+    assert new_strategy_params.max_debt == old_max_debt
+    assert new_strategy_params.last_report == pytest.approx(snapshot, abs=1)
+
+    old_strategy_params = vault.strategies(old_strategy)
+    checks.check_revoked_strategy(old_strategy_params)
+
+
+def test_migrate_lossy_strategy__with_existing_debt__migrates(
+    gov,
+    asset,
+    user_deposit,
+    create_vault,
+    mint_and_deposit_into_vault,
+    create_lossy_strategy,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+    fish_amount,
+    fish
+):  
+    vault = create_vault(asset)
+    lossy_strategy = create_lossy_strategy(vault)
+    amount = fish_amount
+    shares = amount
+
+    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
+    user_deposit(fish, vault, asset, amount)
+    add_strategy_to_vault(gov, lossy_strategy, vault)
+    add_debt_to_strategy(gov, lossy_strategy, vault, amount)
+
+    assert vault.totalAssets() == amount
+    assert vault.strategies(lossy_strategy).current_debt == amount
+
+    amount_to_loose = amount // 2
+    lossy_strategy.setLoss(gov, amount_to_loose, sender=gov)
+    assert asset.balanceOf(lossy_strategy.address) == amount - amount_to_loose
+
+    old_strategy = lossy_strategy
+    new_strategy = create_lossy_strategy(vault)
+
+    old_strategy_params = vault.strategies(old_strategy)
+    old_current_debt = old_strategy_params.current_debt
+    old_max_debt = old_strategy_params.max_debt
+
+    snapshot = chain.pending_timestamp
+    tx = vault.migrate_strategy(new_strategy.address, old_strategy.address, sender=gov)
+
+    event = list(tx.decode_logs(vault.StrategyMigrated))
+
+    assert len(event) == 1
+    assert event[0].old_strategy == old_strategy.address
+    assert event[0].new_strategy == new_strategy.address
+
+    # Funds should still migrate and current debt should stay the same since the loss hasn't been reported
+    new_strategy_params = vault.strategies(new_strategy)
+    assert new_strategy_params.activation == pytest.approx(snapshot, abs=1)
+    assert new_strategy_params.current_debt == old_current_debt
+    assert new_strategy_params.max_debt == old_max_debt
+    assert new_strategy_params.last_report == pytest.approx(snapshot, abs=1)
+
+    old_strategy_params = vault.strategies(old_strategy)
+    checks.check_revoked_strategy(old_strategy_params)
 
 
 def test_migrate_strategy__with_inactive_old_strategy__fails_with_error(


### PR DESCRIPTION
## Description

-Only revert migration if old strategies current_debt > AND call_migrate_strategy == false. This allows funds to be sent from one strategy to the other without having to be pulled back from the vault. Sets the current_debt of old strategy == 0 after migrate call so that the old strategy can be revoked.

-Added tests for normal locked and lossy strategies to make sure funds are properly migrated.

-Note: Can also save 313 gas by caching the "migrated_strategy: StrategyParams = self.strategies[old_strategy]" at the top of the function as to not read from storage for the assert statements. But it will add extra costs for tx's that fail there.

Fixes # (issue)
#123 

## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
