### PR TITLE
fix: remove extra variable update

### DIFF
--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -720,7 +720,6 @@ def _update_debt(strategy: address, target_debt: uint256) -> uint256:
         # if insufficient funds to deposit, transfer only what is free
         if assets_to_deposit > available_idle:
             assets_to_deposit = available_idle
-            new_debt = current_debt + assets_to_deposit
 
         if assets_to_deposit > 0:
             self.erc20_safe_approve(ASSET.address, strategy, assets_to_deposit)


### PR DESCRIPTION
## Description

remove extra update of new_debt variable in _update_debt() 

Fixes # (issue)
#124 
## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
