### PR TITLE
build: add and migrate any 4626 contract

### DIFF
--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -7,7 +7,6 @@ from vyper.interfaces import ERC20Detailed
 # INTERFACES #
 interface IStrategy:
     def asset() -> address: view
-    def vault() -> address: view
     def balanceOf(owner: address) -> uint256: view
     def maxDeposit(receiver: address) -> uint256: view
     def maxWithdraw(owner: address) -> uint256: view
@@ -582,7 +581,6 @@ def _redeem(sender: address, receiver: address, owner: address, shares_to_burn: 
 def _add_strategy(new_strategy: address):
    assert new_strategy != empty(address), "strategy cannot be zero address"
    assert IStrategy(new_strategy).asset() == ASSET.address, "invalid asset"
-   assert IStrategy(new_strategy).vault() == self, "invalid vault"
    assert self.strategies[new_strategy].activation == 0, "strategy already active"
 
    self.strategies[new_strategy] = StrategyParams({
@@ -615,7 +613,6 @@ def _migrate_strategy(new_strategy: address, old_strategy: address, call_migrate
     assert self.strategies[old_strategy].current_debt == 0 or call_migrate_strategy, "old strategy has debt"
     assert new_strategy != empty(address), "strategy cannot be zero address"
     assert IStrategy(new_strategy).asset() == ASSET.address, "invalid asset"
-    assert IStrategy(new_strategy).vault() == self, "invalid vault"
     assert self.strategies[new_strategy].activation == 0, "strategy already active"
 
     migrated_strategy: StrategyParams = self.strategies[old_strategy]

--- a/contracts/test/mocks/ERC4626/Generic4626.sol
+++ b/contracts/test/mocks/ERC4626/Generic4626.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.14;
+
+import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract Generic4626 is ERC4626 {
+    constructor(address _asset)
+        ERC4626(IERC20Metadata(address(_asset)))
+        ERC20("a", "a")
+    {}
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,6 +231,15 @@ def create_lossy_strategy(project, strategist):
     yield create_lossy_strategy
 
 
+# create locked strategy with 0 fee
+@pytest.fixture(scope="session")
+def create_generic_strategy(project, strategist):
+    def create_generic_strategy(asset):
+        return strategist.deploy(project.Generic4626, asset)
+
+    yield create_generic_strategy
+
+
 @pytest.fixture(scope="session")
 def vault(gov, asset, create_vault):
     vault = create_vault(asset)
@@ -259,6 +268,13 @@ def lossy_strategy(gov, vault, create_lossy_strategy):
     strategy = create_lossy_strategy(vault)
     vault.add_strategy(strategy.address, sender=gov)
     strategy.setMaxDebt(MAX_INT, sender=gov)
+    yield strategy
+
+
+@pytest.fixture(scope="session")
+def generic_strategy(gov, vault, create_generic_strategy):
+    strategy = create_generic_strategy(vault.asset())
+    vault.add_strategy(strategy.address, sender=gov)
     yield strategy
 
 


### PR DESCRIPTION
## Description

Dont check the strategy.vault() to allow for any ERC4626 compliant contract to be added as a strategy/

Fixes # (issue)
#128 

## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
