### PR TITLE
fix: plugin version control

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,6 @@ python3 -m pip install -r requirements-dev.txt
 yarn
 ```
 
-
-Fetch the ape plugins:
-
-```
-ape plugins install .
-```
-
-Install plugins with:
-
-`ape plugins install .`
-
 Compile smart contracts with:
 
 ```

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -1,10 +1,5 @@
 name: yearn-v3
 
-plugins:
-  - name: solidity
-  - name: vyper
-  - name: hardhat
-
 default_ecosystem: ethereum
 dependencies:
   - name: openzeppelin

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -1,5 +1,10 @@
 name: yearn-v3
 
+plugins:
+  - name: solidity
+  - name: vyper
+  - name: hardhat
+
 default_ecosystem: ethereum
 dependencies:
   - name: openzeppelin

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,5 @@
 black==22.3.0
 eth-ape==0.5.5
+ape-solidity==0.5.4
+ape-vyper==0.5.2
+ape-hardhat==0.5.5


### PR DESCRIPTION
## Description

The newest releases of the plugins for ape-vyper, ape-solidity and ape-hardhat are causing problems with the used version of ape. Implement version control in the requirements.txt for installation.

Fixes # (issue)

## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
